### PR TITLE
Implement `SpiffeId` type.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ grpcio-tools = "~=1.33.2"
 requests = "~=2.25.0"
 python-json-logger = "~=0.1.11"
 cryptography = "~=3.2.1"
+rfc3987 = "~=1.3.8"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "79541cc6dc7091b9cd1c0e5d6dfdab1b7d9231ddc95f8d637a5eb5ce09d1b18f"
+            "sha256": "851baa8c7d8d1a8e0432390f1534aa55eeef6112ea671143c530c24ff6284e0b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -258,6 +258,14 @@
             "index": "pypi",
             "version": "==2.25.1"
         },
+        "rfc3987": {
+            "hashes": [
+                "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53",
+                "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            ],
+            "index": "pypi",
+            "version": "==1.3.8"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -488,11 +496,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:943cd299ac7f5715fcb3f684e2fc1594c1e0f22a90d15398e5888143bd4144b5",
-                "sha256:cc86e6a9a390879dcc2976cef169dd9cc48843ed70b7380f321d1b118163c60e"
+                "sha256:7aef7a5104d6254c162990e54a203cdc0fd202046b6c415bd5d636472f6565c4",
+                "sha256:b2c71bf9f5c482c389cef816f3a15f1c9d7429ad70f497d4a2e522442d80c6de"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.5.10"
+            "version": "==1.5.11"
         },
         "idna": {
             "hashes": [
@@ -520,11 +528,11 @@
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:7b51f0106c8ec564b1bef3d9c588bc694ce2b92125bbb6278f4f2f5b54ec3592",
-                "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"
+                "sha256:0a948d0c8c3f9344de62997e3f73444dbba233b1eaf24352933c2d264b9e4182",
+                "sha256:6b45007a479c4ec21165ae3ffbe37faf35404e2041fac6ae1da684f38530ca73"
             ],
             "markers": "python_version < '3.7'",
-            "version": "==3.3.0"
+            "version": "==4.1.1"
         },
         "iniconfig": {
             "hashes": [
@@ -710,10 +718,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
-                "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"
+                "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4",
+                "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
             ],
-            "version": "==2020.4"
+            "version": "==2020.5"
         },
         "pyyaml": {
             "hashes": [
@@ -876,38 +884,38 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
-                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
-                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
-                "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
-                "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072",
-                "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298",
-                "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
-                "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+                "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1",
+                "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d",
+                "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6",
+                "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd",
+                "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37",
+                "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151",
+                "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07",
+                "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440",
+                "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70",
+                "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496",
+                "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea",
+                "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400",
+                "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc",
+                "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606",
+                "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc",
+                "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581",
+                "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412",
+                "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a",
+                "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2",
+                "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787",
+                "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f",
+                "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937",
+                "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64",
+                "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487",
+                "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b",
+                "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41",
+                "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a",
+                "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3",
+                "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166",
+                "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     license='Apache License Version 2.0',
     packages=find_packages(where="src", exclude=['test']),
     package_dir={"": "src"},
-    install_requires=[],
+    install_requires=['rfc3987'],
     python_requires='>=3.6',
 )

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -1,17 +1,165 @@
-from src.pyspiffe.spiffe_id.trust_domain import TrustDomain
+from typing import Any
+
+from pyspiffe.spiffe_id import SPIFFE_SCHEME
+from pyspiffe.spiffe_id.trust_domain import TrustDomain
+
+from rfc3987 import parse
+
+SPIFFE_ID_MAXIMUM_LENGTH = 2048
 
 
 class SpiffeId(object):
     """
-    Represents a SPIFFE ID as defined in the SPIFFE standard.
-    see <a href="https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md">https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md</a>
-
-    :param trust_domain: The trust domain corresponds to the trust root of a system.
-    :param path: The path component
+    Represents a SPIFFE ID
+    as defined in the `SPIFFE standard <https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md>`
     """
 
-    schema: str = 'spiffe'
+    @classmethod
+    def parse(cls, spiffe_id: str):
+        """Parses a SPIFFE ID from a string into a SpiffeId type instance.
 
-    def __init__(self, trust_domain: TrustDomain, path: str):
-        self.trust_domain = trust_domain
-        self.path = path
+        Args:
+            spiffe_id: a string representing the SPIFFE ID
+
+        Returns:
+            an instance of a compliant SPIFFE ID (SpiffeId type)
+
+        Raises:
+            ValueError: if the string spiffe_id doesn't comply the the SPIFFE standard.
+
+        Examples:
+            >>> spiffe_id = SpiffeId.parse('spiffe://domain.test/path/element')
+            >>> print(spiffe_id.trust_domain())
+            domain.test
+            >>> print(spiffe_id.path())
+            /path/element
+        """
+
+        if spiffe_id == '' or spiffe_id is None:
+            raise ValueError('SPIFFE ID cannot be empty.')
+
+        uri = cls.parse_and_validate_uri(spiffe_id)
+
+        result = SpiffeId()
+        result.__set_path(uri.get('path'))
+        result.__set_trust_domain(TrustDomain(uri.get('authority')))
+        return result
+
+    @classmethod
+    def of(cls, trust_domain: TrustDomain, path_segments=None):
+        """Creates SpiffeId type instance from a Trust Domain and zero or more paths.
+
+        Args:
+            trust_domain(TrustDomain): The trust domain corresponds to the trust root of a system.
+            path_segments (optional): can be a single string or a list of path segments
+
+        Returns:
+            an instance of a compliant SPIFFE ID (SpiffeId type)
+
+        Raises:
+            ValueError: if the trust_domain is None or is not instance of the class TrustDomain.
+
+        Examples:
+            >>> spiffe_id_1 = SpiffeId.of(TrustDomain('example.org'), 'path')
+            >>> print(spiffe_id_1)
+            spiffe://example.org/path
+
+            an array of paths:
+            >>> spiffe_id_2 = SpiffeId.of(TrustDomain('example.org'), ['path1', 'path2', 'element'])
+            >>> print(spiffe_id_2)
+            spiffe://example.org/path1/path2/element
+        """
+
+        if trust_domain is None:
+            raise ValueError('SPIFFE ID: trust domain cannot be empty.')
+
+        result = SpiffeId()
+        if isinstance(trust_domain, TrustDomain):
+            result.__set_trust_domain(trust_domain)
+        else:
+            raise ValueError(
+                'SPIFFE ID: trust_domain argument must be a TrustDomain instance.'
+            )
+
+        if path_segments is not None:
+            result.__set_path(path_segments)
+
+        cls.parse_and_validate_uri(str(result))
+        return result
+
+    def __eq__(self, other: Any):
+        if isinstance(other, self.__class__):
+            return (
+                self.__trust_domain == other.__trust_domain
+                and self.__path == other.path()
+            )
+
+    def __str__(self):
+        if self.__path is not None:
+            return '{}://{}{}'.format(
+                SPIFFE_SCHEME, self.__trust_domain.name(), self.__path
+            )
+        else:
+            return '{}://{}'.format(SPIFFE_SCHEME, self.__trust_domain.name())
+
+    # path_segments can be an array of path segments or a single string representing a path
+    def __set_path(self, path: Any):
+        if isinstance(path, list):
+            self.__path = ''
+            for s in path:
+                self.__path += self.normalize_path(s)
+        else:
+            self.__path = self.normalize_path(path)
+
+    def __set_trust_domain(self, trust_domain: TrustDomain):
+        self.__trust_domain = trust_domain
+
+    def path(self):
+        return self.__path
+
+    def trust_domain(self):
+        return self.__trust_domain
+
+    @classmethod
+    def parse_and_validate_uri(cls, spiffe_id: str):
+        if len(spiffe_id) > SPIFFE_ID_MAXIMUM_LENGTH:
+            raise ValueError(
+                'SPIFFE ID: maximum length is {} bytes.'.format(
+                    SPIFFE_ID_MAXIMUM_LENGTH
+                )
+            )
+
+        uri = parse(spiffe_id.strip(), rule='URI')
+
+        scheme = uri.get('scheme')
+        if not scheme.lower() == SPIFFE_SCHEME:
+            raise ValueError('SPIFFE ID: invalid scheme: expected spiffe.')
+
+        query = uri.get('query')
+        if query is not None and not query == '':
+            raise ValueError('SPIFFE ID: query is not allowed.')
+
+        fragment = uri.get('fragment')
+        if fragment is not None and not fragment == '':
+            raise ValueError('SPIFFE ID: fragment is not allowed.')
+
+        authority = uri.get('authority')
+        if authority == '' or authority is None:
+            raise ValueError('SPIFFE ID: trust domain cannot be empty.')
+
+        # has user@info:
+        if '@' in authority:
+            raise ValueError('SPIFFE ID: user info is not allowed.')
+
+        # has domain:port
+        if ':' in authority:
+            raise ValueError('SPIFFE ID: port is not allowed.')
+
+        return uri
+
+    @staticmethod
+    def normalize_path(path: str):
+        path = path.strip()
+        if path and not path.startswith('/'):
+            return '/' + path
+        return path

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -122,8 +122,8 @@ class SpiffeId(object):
     def is_member_of(self, trust_domain: TrustDomain) -> bool:
         return self.__trust_domain == trust_domain
 
-    @classmethod
-    def parse_and_validate_uri(cls, spiffe_id: str) -> dict:
+    @staticmethod
+    def parse_and_validate_uri(spiffe_id: str) -> dict:
         if len(spiffe_id) > SPIFFE_ID_MAXIMUM_LENGTH:
             raise ValueError(
                 'SPIFFE ID: maximum length is {} bytes.'.format(
@@ -151,7 +151,7 @@ class SpiffeId(object):
 
         # has user@info:
         if '@' in authority:
-            raise ValueError('SPIFFE ID: user info is not allowed.')
+            raise ValueError('SPIFFE ID: userinfo is not allowed.')
 
         # has domain:port
         if ':' in authority:

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -73,13 +73,13 @@ class SpiffeId(object):
         if trust_domain is None:
             raise ValueError('SPIFFE ID: trust domain cannot be empty.')
 
-        result = SpiffeId()
-        if isinstance(trust_domain, TrustDomain):
-            result.__set_trust_domain(trust_domain)
-        else:
+        if not isinstance(trust_domain, TrustDomain):
             raise ValueError(
                 'SPIFFE ID: trust_domain argument must be a TrustDomain instance.'
             )
+
+        result = SpiffeId()
+        result.__set_trust_domain(trust_domain)
 
         if path_segments is not None:
             result.__set_path(path_segments)
@@ -87,15 +87,15 @@ class SpiffeId(object):
         cls.parse_and_validate_uri(str(result))
         return result
 
-    def __eq__(self, other: Any):
-        if isinstance(other, self.__class__):
-            return (
-                self.__trust_domain == other.__trust_domain
-                and self.__path == other.path()
-            )
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return (
+            self.__trust_domain == other.__trust_domain and self.__path == other.path()
+        )
 
-    def __str__(self):
-        if self.__path is not None:
+    def __str__(self) -> str:
+        if self.__path:
             return '{}://{}{}'.format(
                 SPIFFE_SCHEME, self.__trust_domain.name(), self.__path
             )
@@ -135,19 +135,19 @@ class SpiffeId(object):
         uri = parse(spiffe_id.strip(), rule='URI')
 
         scheme = uri.get('scheme')
-        if not scheme.lower() == SPIFFE_SCHEME:
+        if scheme.lower() != SPIFFE_SCHEME:
             raise ValueError('SPIFFE ID: invalid scheme: expected spiffe.')
 
         query = uri.get('query')
-        if query is not None and not query == '':
+        if query:
             raise ValueError('SPIFFE ID: query is not allowed.')
 
         fragment = uri.get('fragment')
-        if fragment is not None and not fragment == '':
+        if fragment:
             raise ValueError('SPIFFE ID: fragment is not allowed.')
 
         authority = uri.get('authority')
-        if authority == '' or authority is None:
+        if not authority:
             raise ValueError('SPIFFE ID: trust domain cannot be empty.')
 
         # has user@info:

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -15,7 +15,7 @@ class SpiffeId(object):
     """
 
     @classmethod
-    def parse(cls, spiffe_id: str):
+    def parse(cls, spiffe_id: str) -> 'SpiffeId':
         """Parses a SPIFFE ID from a string into a SpiffeId type instance.
 
         Args:
@@ -46,7 +46,7 @@ class SpiffeId(object):
         return result
 
     @classmethod
-    def of(cls, trust_domain: TrustDomain, path_segments=None):
+    def of(cls, trust_domain: TrustDomain, path_segments=None) -> 'SpiffeId':
         """Creates SpiffeId type instance from a Trust Domain and zero or more paths.
 
         Args:
@@ -114,17 +114,17 @@ class SpiffeId(object):
     def __set_trust_domain(self, trust_domain: TrustDomain):
         self.__trust_domain = trust_domain
 
-    def path(self):
+    def path(self) -> str:
         return self.__path
 
-    def trust_domain(self):
+    def trust_domain(self) -> TrustDomain:
         return self.__trust_domain
 
-    def is_member_of(self, trust_domain: TrustDomain):
+    def is_member_of(self, trust_domain: TrustDomain) -> bool:
         return self.__trust_domain == trust_domain
 
     @classmethod
-    def parse_and_validate_uri(cls, spiffe_id: str):
+    def parse_and_validate_uri(cls, spiffe_id: str) -> dict:
         if len(spiffe_id) > SPIFFE_ID_MAXIMUM_LENGTH:
             raise ValueError(
                 'SPIFFE ID: maximum length is {} bytes.'.format(
@@ -161,7 +161,7 @@ class SpiffeId(object):
         return uri
 
     @staticmethod
-    def normalize_path(path: str):
+    def normalize_path(path: str) -> str:
         path = path.strip()
         if path and not path.startswith('/'):
             return '/' + path

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -120,6 +120,9 @@ class SpiffeId(object):
     def trust_domain(self):
         return self.__trust_domain
 
+    def is_member_of(self, trust_domain: TrustDomain):
+        return self.__trust_domain == trust_domain
+
     @classmethod
     def parse_and_validate_uri(cls, spiffe_id: str):
         if len(spiffe_id) > SPIFFE_ID_MAXIMUM_LENGTH:

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -99,19 +99,18 @@ class SpiffeId(object):
             return '{}://{}{}'.format(
                 SPIFFE_SCHEME, self.__trust_domain.name(), self.__path
             )
-        else:
-            return '{}://{}'.format(SPIFFE_SCHEME, self.__trust_domain.name())
+        return '{}://{}'.format(SPIFFE_SCHEME, self.__trust_domain.name())
 
     # path_segments can be an array of path segments or a single string representing a path
-    def __set_path(self, path: Any):
+    def __set_path(self, path: Any) -> None:
         if isinstance(path, list):
             self.__path = ''
             for s in path:
                 self.__path += self.normalize_path(s)
-        else:
-            self.__path = self.normalize_path(path)
+            return
+        self.__path = self.normalize_path(path)
 
-    def __set_trust_domain(self, trust_domain: TrustDomain):
+    def __set_trust_domain(self, trust_domain: TrustDomain) -> None:
         self.__trust_domain = trust_domain
 
     def path(self) -> str:

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -45,7 +45,7 @@ class TrustDomain(object):
         return '{}://{}'.format(SPIFFE_SCHEME, self.__name)
 
     def __set_name(self, name: str):
-        if name == '' or name is None:
+        if not name:
             raise ValueError(EMPTY_DOMAIN_ERROR)
 
         if len(name) > TRUST_DOMAIN_MAXIMUM_LENGTH:
@@ -68,11 +68,11 @@ class TrustDomain(object):
 
     @staticmethod
     def validate_uri(uri: Tuple):
-        if not uri.scheme == SPIFFE_SCHEME:
+        if uri.scheme != SPIFFE_SCHEME:
             raise ValueError(
                 'Trust domain: invalid scheme: expected {}.'.format(SPIFFE_SCHEME)
             )
-        if uri.hostname is None:
+        if not uri.hostname:
             raise ValueError(EMPTY_DOMAIN_ERROR)
-        if uri.port is not None:
+        if uri.port:
             raise ValueError('Trust domain: port is not allowed.')

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -44,7 +44,7 @@ class TrustDomain(object):
     def as_str_id(self) -> str:
         return '{}://{}'.format(SPIFFE_SCHEME, self.__name)
 
-    def __set_name(self, name: str):
+    def __set_name(self, name: str) -> None:
         if not name:
             raise ValueError(EMPTY_DOMAIN_ERROR)
 
@@ -67,7 +67,7 @@ class TrustDomain(object):
         return name
 
     @staticmethod
-    def validate_uri(uri: Tuple):
+    def validate_uri(uri: Tuple) -> None:
         if uri.scheme != SPIFFE_SCHEME:
             raise ValueError(
                 'Trust domain: invalid scheme: expected {}.'.format(SPIFFE_SCHEME)

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -3,8 +3,9 @@ from typing import Tuple, Any
 
 from pyspiffe.spiffe_id import SPIFFE_SCHEME
 
-EMPTY_DOMAIN_ERROR = 'Trust domain cannot be empty'
+EMPTY_DOMAIN_ERROR = 'Trust domain cannot be empty.'
 SCHEME_SUFFIX = '://'
+TRUST_DOMAIN_MAXIMUM_LENGTH = 255
 
 
 class TrustDomain(object):
@@ -17,6 +18,13 @@ class TrustDomain(object):
     Raises:
         ValueError: if the name of the trust domain is empty, has a port, or contains an invalid scheme.
 
+    Examples:
+        >>> trust_domain = TrustDomain('Domain.Test')
+        >>> print(trust_domain)
+        domain.test
+
+        >>> print(trust_domain.as_str_id())
+        spiffe://domain.test
     """
 
     def __init__(self, name: str):
@@ -26,16 +34,26 @@ class TrustDomain(object):
         return self.__name
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, TrustDomain):
+        if isinstance(other, self.__class__):
             return self.__name == other.name()
         return False
 
     def name(self) -> str:
         return self.__name
 
+    def as_str_id(self):
+        return '{}://{}'.format(SPIFFE_SCHEME, self.__name)
+
     def __set_name(self, name: str):
         if name == '' or name is None:
             raise ValueError(EMPTY_DOMAIN_ERROR)
+
+        if len(name) > TRUST_DOMAIN_MAXIMUM_LENGTH:
+            raise ValueError(
+                'Trust domain cannot be longer than {} bytes.'.format(
+                    TRUST_DOMAIN_MAXIMUM_LENGTH
+                )
+            )
 
         name = self.normalize(name)
         uri = urlparse(name)
@@ -52,9 +70,9 @@ class TrustDomain(object):
     def validate_uri(uri: Tuple):
         if not uri.scheme == SPIFFE_SCHEME:
             raise ValueError(
-                'Trust domain: invalid scheme: expected {}'.format(SPIFFE_SCHEME)
+                'Trust domain: invalid scheme: expected {}.'.format(SPIFFE_SCHEME)
             )
         if uri.hostname is None:
             raise ValueError(EMPTY_DOMAIN_ERROR)
         if uri.port is not None:
-            raise ValueError('Trust domain: port is not allowed')
+            raise ValueError('Trust domain: port is not allowed.')

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -41,7 +41,7 @@ class TrustDomain(object):
     def name(self) -> str:
         return self.__name
 
-    def as_str_id(self):
+    def as_str_id(self) -> str:
         return '{}://{}'.format(SPIFFE_SCHEME, self.__name)
 
     def __set_name(self, name: str):

--- a/test/spiffe_id/test_spiffe_id.py
+++ b/test/spiffe_id/test_spiffe_id.py
@@ -156,29 +156,29 @@ def test_of_empty_trust_domain():
 
 
 def test_exceeds_maximum_length():
-    path = "a" * 2028
+    path = 'a' * 2028
 
     with pytest.raises(ValueError) as exception:
-        SpiffeId.parse("spiffe://example.org/{}".format(path))
+        SpiffeId.parse('spiffe://example.org/{}'.format(path))
 
     assert str(exception.value) == 'SPIFFE ID: maximum length is 2048 bytes.'
 
 
 def test_maximum_length():
-    path = "a" * 2027
-    spiffe_id = SpiffeId.parse("spiffe://example.org/{}".format(path))
+    path = 'a' * 2027
+    spiffe_id = SpiffeId.parse('spiffe://example.org/{}'.format(path))
 
     assert spiffe_id.trust_domain() == TrustDomain('example.org')
     assert spiffe_id.path() == '/' + path
 
 
 def test_is_member_of():
-    spiffe_id = SpiffeId.parse("spiffe://domain.test/path/element")
-    trust_domain = TrustDomain("domain.test")
+    spiffe_id = SpiffeId.parse('spiffe://domain.test/path/element')
+    trust_domain = TrustDomain('domain.test')
     assert spiffe_id.is_member_of(trust_domain)
 
 
 def test_is_not_member_of():
-    spiffe_id = SpiffeId.parse("spiffe://domain.test/path/element")
-    trust_domain = TrustDomain("other.test")
+    spiffe_id = SpiffeId.parse('spiffe://domain.test/path/element')
+    trust_domain = TrustDomain('other.test')
     assert not spiffe_id.is_member_of(trust_domain)

--- a/test/spiffe_id/test_spiffe_id.py
+++ b/test/spiffe_id/test_spiffe_id.py
@@ -170,3 +170,15 @@ def test_maximum_length():
 
     assert spiffe_id.trust_domain() == TrustDomain('example.org')
     assert spiffe_id.path() == '/' + path
+
+
+def test_is_member_of():
+    spiffe_id = SpiffeId.parse("spiffe://domain.test/path/element")
+    trust_domain = TrustDomain("domain.test")
+    assert spiffe_id.is_member_of(trust_domain)
+
+
+def test_is_not_member_of():
+    spiffe_id = SpiffeId.parse("spiffe://domain.test/path/element")
+    trust_domain = TrustDomain("other.test")
+    assert not spiffe_id.is_member_of(trust_domain)

--- a/test/spiffe_id/test_spiffe_id.py
+++ b/test/spiffe_id/test_spiffe_id.py
@@ -1,0 +1,172 @@
+import pytest
+
+from pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.spiffe_id.spiffe_id import SpiffeId
+
+
+@pytest.mark.parametrize(
+    'trust_domain,path_segments,expected_spiffe_id',
+    [
+        (
+            TrustDomain('example.org'),
+            ['path', 'element'],
+            'spiffe://example.org/path/element',
+        ),
+        (
+            TrustDomain('example.org'),
+            ['/path', '/element'],
+            'spiffe://example.org/path/element',
+        ),
+        # path case should be preserved
+        (
+            TrustDomain('domain.test'),
+            ['   pAth1  ', '   pATH2  '],
+            'spiffe://domain.test/pAth1/pATH2',
+        ),
+        (
+            TrustDomain('domain.test'),
+            '   pAth1/pATH2  ',
+            'spiffe://domain.test/pAth1/pATH2',
+        ),
+        (
+            TrustDomain('domain.test'),
+            ['   pAth1/pATH2  '],
+            'spiffe://domain.test/pAth1/pATH2',
+        ),
+    ],
+)
+def test_of_trust_domain_and_segments(trust_domain, path_segments, expected_spiffe_id):
+    result = SpiffeId.of(trust_domain, path_segments)
+    assert str(result) == expected_spiffe_id
+
+
+@pytest.mark.parametrize(
+    'spiffe_id_str,expected_trust_domain,expected_path',
+    [
+        ('spiffe://example.org', TrustDomain('example.org'), ''),
+        (
+            'spiffe://example.org/path1/path2',
+            TrustDomain('example.org'),
+            '/path1/path2',
+        ),
+        # only path case should be preserved
+        (
+            'SPIFFE://EXAMPLE.oRg/pAth1/pATH2',
+            TrustDomain('example.org'),
+            '/pAth1/pATH2',
+        ),
+        (
+            '    spiffe://EXAMPLE.oRg/PATH1/PATH2   ',
+            TrustDomain('example.org'),
+            '/PATH1/PATH2',
+        ),
+        (
+            'spiffe://domain.test/pa@th/element:',
+            TrustDomain('domain.test'),
+            '/pa@th/element:',
+        ),
+        (
+            "spiffe://domain.test/p!a$t&h'/(e)l*e+m,e;n=t",
+            TrustDomain('domain.test'),
+            "/p!a$t&h'/(e)l*e+m,e;n=t",
+        ),
+    ],
+)
+def test_parse_spiffe_id_valid_uri(spiffe_id_str, expected_trust_domain, expected_path):
+    spiffe_id = SpiffeId.parse(spiffe_id_str)
+    assert spiffe_id.trust_domain() == expected_trust_domain
+    assert spiffe_id.path() == expected_path
+
+
+@pytest.mark.parametrize(
+    'spiffe_id_str,expected',
+    [
+        ('', 'SPIFFE ID cannot be empty.'),
+        (None, 'SPIFFE ID cannot be empty.'),
+        ('192.168.2.2:6688', "'192.168.2.2:6688' is not a valid 'URI'."),
+        (
+            'http://domain.test/path/element',
+            'SPIFFE ID: invalid scheme: expected spiffe.',
+        ),
+        ('spiffe:///path/element', 'SPIFFE ID: trust domain cannot be empty.'),
+        (
+            'spiffe://domain.test/path/element?query=1',
+            'SPIFFE ID: query is not allowed.',
+        ),
+        (
+            'spiffe://domain.test/path/element#fragment-1',
+            'SPIFFE ID: fragment is not allowed.',
+        ),
+        ('spiffe://domain.test:8080/path/element', 'SPIFFE ID: port is not allowed.'),
+        (
+            'spiffe://user:password@test.org/path/element',
+            'SPIFFE ID: user info is not allowed.',
+        ),
+        ('spiffe:path/element', 'SPIFFE ID: trust domain cannot be empty.'),
+        ('spiffe:/path/element', 'SPIFFE ID: trust domain cannot be empty.'),
+        (
+            'spiffe://domain.test/path/elem%5uent',
+            "'spiffe://domain.test/path/elem%5uent' is not a valid 'URI'.",
+        ),
+    ],
+)
+def test_parse_spiffe_id_from_invalid_uri_string(spiffe_id_str, expected):
+    with pytest.raises(ValueError) as exception:
+        SpiffeId.parse(spiffe_id_str)
+
+    assert str(exception.value) == expected
+
+
+def test_not_equal_spiffe_ids():
+    trust_domain = TrustDomain('domain.test')
+    spiffeid_1 = SpiffeId.of(trust_domain, 'path1')
+    spiffeid_2 = SpiffeId.of(trust_domain, 'path2')
+    assert spiffeid_1 != spiffeid_2
+
+
+def test_equal_spiffe_id():
+    trust_domain = TrustDomain('domain.test')
+    spiffeid_1 = SpiffeId.of(trust_domain, 'path1')  # path1 is normalized as /path1
+    spiffeid_2 = SpiffeId.of(trust_domain, '/path1')
+    assert spiffeid_1 == spiffeid_2
+
+
+def test_equal_spiffe_id_with_multiple_paths():
+    trust_domain = TrustDomain('example.org')
+    spiffeid_1 = SpiffeId.of(trust_domain, ['PATH1', 'PATH2'])
+    spiffeid_2 = SpiffeId.of(trust_domain, ['/PATH1', '/PATH2'])
+    assert spiffeid_1 == spiffeid_2
+
+
+def test_trust_domain_none():
+    with pytest.raises(ValueError) as exception:
+        SpiffeId.of(None, 'path')
+
+    assert str(exception.value) == 'SPIFFE ID: trust domain cannot be empty.'
+
+
+def test_of_empty_trust_domain():
+    with pytest.raises(ValueError) as exception:
+        SpiffeId.of('', 'path')
+
+    assert (
+        str(exception.value)
+        == 'SPIFFE ID: trust_domain argument must be a TrustDomain instance.'
+    )
+
+
+def test_exceeds_maximum_length():
+    path = "a" * 2028
+
+    with pytest.raises(ValueError) as exception:
+        SpiffeId.parse("spiffe://example.org/{}".format(path))
+
+    assert str(exception.value) == 'SPIFFE ID: maximum length is 2048 bytes.'
+
+
+def test_maximum_length():
+    path = "a" * 2027
+    spiffe_id = SpiffeId.parse("spiffe://example.org/{}".format(path))
+
+    assert spiffe_id.trust_domain() == TrustDomain('example.org')
+    assert spiffe_id.path() == '/' + path

--- a/test/spiffe_id/test_spiffe_id.py
+++ b/test/spiffe_id/test_spiffe_id.py
@@ -100,7 +100,7 @@ def test_parse_spiffe_id_valid_uri(spiffe_id_str, expected_trust_domain, expecte
         ('spiffe://domain.test:8080/path/element', 'SPIFFE ID: port is not allowed.'),
         (
             'spiffe://user:password@test.org/path/element',
-            'SPIFFE ID: user info is not allowed.',
+            'SPIFFE ID: userinfo is not allowed.',
         ),
         ('spiffe:path/element', 'SPIFFE ID: trust domain cannot be empty.'),
         ('spiffe:/path/element', 'SPIFFE ID: trust domain cannot be empty.'),

--- a/test/spiffe_id/test_trust_domain.py
+++ b/test/spiffe_id/test_trust_domain.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.spiffe_id.trust_domain import TrustDomain
 
 
 @pytest.mark.parametrize(
@@ -22,13 +22,13 @@ def test_valid_trust_domain(test_input, expected):
 @pytest.mark.parametrize(
     'test_input,expected',
     [
-        ('', 'Trust domain cannot be empty'),
-        (None, 'Trust domain cannot be empty'),
-        ('http://domain.test', 'Trust domain: invalid scheme: expected spiffe'),
-        ('://domain.test', 'Trust domain: invalid scheme: expected spiffe'),
-        ('spiffe:///path/element', 'Trust domain cannot be empty'),
-        ('/path/element', 'Trust domain cannot be empty'),
-        ('spiffe://domain.test:80', 'Trust domain: port is not allowed'),
+        ('', 'Trust domain cannot be empty.'),
+        (None, 'Trust domain cannot be empty.'),
+        ('http://domain.test', 'Trust domain: invalid scheme: expected spiffe.'),
+        ('://domain.test', 'Trust domain: invalid scheme: expected spiffe.'),
+        ('spiffe:///path/element', 'Trust domain cannot be empty.'),
+        ('/path/element', 'Trust domain cannot be empty.'),
+        ('spiffe://domain.test:80', 'Trust domain: port is not allowed.'),
     ],
 )
 def test_invalid_trust_domain(test_input, expected):
@@ -58,3 +58,24 @@ def test_compare_different_trust_domains():
     trust_domain1 = TrustDomain('domain.test')
     trust_domain2 = TrustDomain('other.test')
     assert not trust_domain1 == trust_domain2
+
+
+def test_exceeds_maximum_length():
+    name = "a" * 256
+
+    with pytest.raises(ValueError) as exception:
+        TrustDomain("{}".format(name))
+
+    assert str(exception.value) == 'Trust domain cannot be longer than 255 bytes.'
+
+
+def test_maximum_length():
+    name = "a" * 255
+    trust_domain = TrustDomain('{}'.format(name))
+
+    assert trust_domain.name() == name
+
+
+def test_as_str_id():
+    trust_domain = TrustDomain('example.org')
+    assert trust_domain.as_str_id() == 'spiffe://example.org'


### PR DESCRIPTION
Implement the strong type `SpiffeId` following the SPIFFE standard.

Add some missing methods and validations to `TrustDomain` type.

Addresses #4 