### PR TITLE
Update Travis config to run the test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-    - "3.9"
+dist: focal
+
+jobs:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
 
 # command to install dependencies
-install: "make dev"
+install: "pip install tox"
 
 # command to run tests
 script:
-    - make test
+    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,5 @@ envlist = py36,py37,py38,py39
 isolated_build = True
 
 [testenv]
-;changedir = tests
 deps = pytest
 commands = python -m pytest test


### PR DESCRIPTION
Updates Travis-CI config at `.travis.yml` to run the test for the library on different versions of Python.

Changes:
- Set dist to `focal`. **Question:** Should we consider using an older one?
- Specifies the correct `tox` environment for each Python version
- Runs `tox` directly without calling `make test`

`make test` reminds for running the test locally at development.

