### PR TITLE
Config setter improvements

### DIFF
--- a/src/pyspiffe/config.py
+++ b/src/pyspiffe/config.py
@@ -71,7 +71,7 @@ class ConfigSetter:
     def _validate_tcp_socket(cls, socket: ParseResult) -> None:
         try:
             ipaddress.ip_address(socket.hostname)
-        except:
+        except ValueError:
             raise ValueError('SPIFFE endpoint socket: host must be an IP address.')
 
         cls._validate_forbidden_components(socket, cls.TCP_FORBIDDEN_SOCKET_COMPONENTS)

--- a/src/pyspiffe/config.py
+++ b/src/pyspiffe/config.py
@@ -1,18 +1,27 @@
 import os
 import ipaddress
 from urllib.parse import ParseResult, urlparse
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 
 SPIFFE_ENDPOINT_SOCKET = 'SPIFFE_ENDPOINT_SOCKET'
 
 
+class Config:
+    """
+    Represents the configuration for a Workload API client
+    """
+
+    def __init__(self, spiffe_endpoint_socket: str):
+        self.spiffe_endpoint_socket = spiffe_endpoint_socket
+
+
 class ConfigSetter:
     """
-    Loads and validates configuration variables from the environment
+    Loads and validates configuration variables
 
     Raises:
-        ValueError: if any variable from the environment has an invalid format
+        ValueError: if any configuration variable has an invalid format
     """
 
     FORBIDDEN_SOCKET_COMPONENTS = [
@@ -28,44 +37,57 @@ class ConfigSetter:
 
     TCP_FORBIDDEN_SOCKET_COMPONENTS = FORBIDDEN_SOCKET_COMPONENTS + [('path', None)]
 
-    def __init__(self):
-        self._apply_default_config()
-        self._apply_environment_variables()
+    def __init__(self, spiffe_endpoint_socket: str = None) -> None:
+        self.__apply_default_config()
+        self.__apply_environment_variables()
 
-    def get_config(self) -> Dict:
-        return self._config
+        if spiffe_endpoint_socket:
+            self.__raw_config[SPIFFE_ENDPOINT_SOCKET] = spiffe_endpoint_socket
 
-    def _apply_default_config(self) -> None:
-        self._config = {
+        self.__validate()
+        self.__config = Config(
+            spiffe_endpoint_socket=self.__raw_config[SPIFFE_ENDPOINT_SOCKET]
+        )
+
+    def get_config(self) -> Config:
+        return self.__config
+
+    def __apply_default_config(self) -> None:
+        self.__raw_config = {
             SPIFFE_ENDPOINT_SOCKET: None,
         }
 
-    def _apply_environment_variables(self) -> None:
+    def __apply_environment_variables(self) -> None:
         endpoint_socket = os.environ.get(SPIFFE_ENDPOINT_SOCKET)
 
         if endpoint_socket:
-            self._validate(endpoint_socket)
-            self._config[SPIFFE_ENDPOINT_SOCKET] = endpoint_socket
+            self.__raw_config[SPIFFE_ENDPOINT_SOCKET] = endpoint_socket
 
-    def _validate(self, socket: str) -> None:
-        parsed_socket = urlparse(socket)
+    def __validate(self) -> None:
+        endpoint_socket = self.__raw_config[SPIFFE_ENDPOINT_SOCKET]
+        if not endpoint_socket:
+            raise ValueError('SPIFFE endpoint socket: socket must be set.')
+
+        parsed_socket = urlparse(endpoint_socket)
 
         if not parsed_socket.scheme:
             raise ValueError('SPIFFE endpoint socket: scheme must be set.')
 
         if parsed_socket.scheme == 'unix':
-            self._validate_unix_socket(parsed_socket)
+            self.__validate_unix_socket(parsed_socket)
         elif parsed_socket.scheme == 'tcp':
             self._validate_tcp_socket(parsed_socket)
         else:
             raise ValueError('SPIFFE endpoint socket: unsupported scheme.')
 
     @classmethod
-    def _validate_unix_socket(cls, socket: ParseResult) -> None:
+    def __validate_unix_socket(cls, socket: ParseResult) -> None:
         if not socket.path:
             raise ValueError('SPIFFE endpoint socket: path must be set.')
 
-        cls._validate_forbidden_components(socket, cls.UNIX_FORBIDDEN_SOCKET_COMPONENTS)
+        cls.__validate_forbidden_components(
+            socket, cls.UNIX_FORBIDDEN_SOCKET_COMPONENTS
+        )
 
     @classmethod
     def _validate_tcp_socket(cls, socket: ParseResult) -> None:
@@ -74,10 +96,10 @@ class ConfigSetter:
         except ValueError:
             raise ValueError('SPIFFE endpoint socket: host must be an IP address.')
 
-        cls._validate_forbidden_components(socket, cls.TCP_FORBIDDEN_SOCKET_COMPONENTS)
+        cls.__validate_forbidden_components(socket, cls.TCP_FORBIDDEN_SOCKET_COMPONENTS)
 
     @classmethod
-    def _validate_forbidden_components(
+    def __validate_forbidden_components(
         cls, socket: ParseResult, components: List[Tuple[str, str]]
     ) -> None:
         for component, description in components:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,16 +3,24 @@ from pyspiffe.config import ConfigSetter
 import os
 
 
+@pytest.fixture(autouse=True)
+def restore_env_vars():
+    env_vars = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(env_vars)
+
+
 def test_create():
     setter = ConfigSetter()
 
-    assert setter != None
+    assert setter is not None
 
 
 def test_default_values():
     setter = ConfigSetter()
 
-    assert setter.get_config()['SPIFFE_ENDPOINT_SOCKET'] == None
+    assert setter.get_config()['SPIFFE_ENDPOINT_SOCKET'] is None
 
 
 def test_read_value_from_environment_variables():


### PR DESCRIPTION
- Adds the ability to set the socket endpoint programmatically
- Returns a Config object instead of a dict

Usage:
```python
config = ConfigSetter(spiffe_endpoint_socket='unix:///path/to/endpoint.sock')
config.spiffe_endpoint_socket
```

`ConfigSetter` first reads from the environment variable `SPIFFE_ENDPOINT_SOCKET`, if set, and then overrides the value with the parameter `spiffe_endpoint_socket`, if set. It raises a `ValueError` when neither of the values are set, or if it's set but is has an invalid socket path.