### PR TITLE
Removes old references to src directory on imports. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # py-spiffe Library
 
+[![Build Status](https://travis-ci.com/HewlettPackard/py-spiffe.svg?branch=master)](https://travis-ci.com/HewlettPackard/py-spiffe)
+
 ## Overview
 Initial work in progress to create a python library for SPIFFE.
 

--- a/src/pyspiffe/bundle/jwt_bundle/jwt_bundle_set.py
+++ b/src/pyspiffe/bundle/jwt_bundle/jwt_bundle_set.py
@@ -1,6 +1,6 @@
 from typing import Mapping
-from .jwt_bundle import JwtBundle
-from src.pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
+from pyspiffe.spiffe_id.trust_domain import TrustDomain
 
 
 class JwtBundleSet(object):

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -1,6 +1,6 @@
 from typing import Mapping
-from .x509_bundle import X509Bundle
-from src.pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.bundle.x509_bundle.x509_bundle import X509Bundle
+from pyspiffe.spiffe_id.trust_domain import TrustDomain
 
 
 class X509BundleSet(object):

--- a/src/pyspiffe/svid/jwt_svid.py
+++ b/src/pyspiffe/svid/jwt_svid.py
@@ -1,5 +1,5 @@
 from typing import List
-from src.pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.spiffe_id.spiffe_id import SpiffeId
 
 
 class JwtSvid(object):

--- a/src/pyspiffe/svid/x509_svid.py
+++ b/src/pyspiffe/svid/x509_svid.py
@@ -1,6 +1,6 @@
 from typing import Mapping, Set
 from datetime import datetime
-from src.pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.spiffe_id.spiffe_id import SpiffeId
 
 
 class X509Svid(object):


### PR DESCRIPTION
This PR includes two simple changes:

- Removes old references to `src` directory on imports. 
- Adds the build badges from Travis to README.md file

I just want to have this changes in a different commit and not as part of a feature where they can be camouflaged.