### PR TITLE
Update mypy task to run against the src package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ flake8:
 
 mypy:
 	@echo "Running mypy."
-	$(PIPENV_CMD) run mypy -m src
+	$(PIPENV_CMD) run mypy --ignore-missing-imports src
 
 
 #------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ flake8:
 
 mypy:
 	@echo "Running mypy."
-	$(PIPENV_CMD) run mypy --ignore-missing-imports src
+	MYPYPATH=src $(PIPENV_CMD) run mypy --ignore-missing-imports -p pyspiffe
 
 
 #------------------------------------------------------------------------

--- a/src/pyspiffe/config.py
+++ b/src/pyspiffe/config.py
@@ -4,7 +4,7 @@
 import os
 import ipaddress
 from urllib.parse import ParseResult, urlparse
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict, cast
 
 
 _SPIFFE_ENDPOINT_SOCKET = 'SPIFFE_ENDPOINT_SOCKET'
@@ -29,7 +29,7 @@ class Config:
 class ConfigSetter:
     """Loads and validates configuration variables."""
 
-    _FORBIDDEN_SOCKET_COMPONENTS = [
+    _FORBIDDEN_SOCKET_COMPONENTS: List[Tuple[str, Optional[str]]] = [
         ('fragment', None),
         ('username', None),
         ('password', None),
@@ -60,16 +60,14 @@ class ConfigSetter:
 
         self._validate()
         self._config = Config(
-            spiffe_endpoint_socket=self._raw_config[_SPIFFE_ENDPOINT_SOCKET]
+            spiffe_endpoint_socket=cast(str, self._raw_config[_SPIFFE_ENDPOINT_SOCKET])
         )
 
     def get_config(self) -> Config:
         return self._config
 
     def _apply_default_config(self) -> None:
-        self._raw_config = {
-            _SPIFFE_ENDPOINT_SOCKET: None,
-        }
+        self._raw_config: Dict[str, Optional[str]] = {_SPIFFE_ENDPOINT_SOCKET: None}
 
     def _apply_environment_variables(self) -> None:
         endpoint_socket = os.environ.get(_SPIFFE_ENDPOINT_SOCKET)

--- a/src/pyspiffe/spiffe_id/spiffe_id.py
+++ b/src/pyspiffe/spiffe_id/spiffe_id.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List, Union, Dict
 
 from pyspiffe.spiffe_id import SPIFFE_SCHEME
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
@@ -41,12 +41,14 @@ class SpiffeId(object):
         uri = cls.parse_and_validate_uri(spiffe_id)
 
         result = SpiffeId()
-        result.__set_path(uri.get('path'))
-        result.__set_trust_domain(TrustDomain(uri.get('authority')))
+        result.__set_path(uri['path'])
+        result.__set_trust_domain(TrustDomain(uri['authority']))
         return result
 
     @classmethod
-    def of(cls, trust_domain: TrustDomain, path_segments=None) -> 'SpiffeId':
+    def of(
+        cls, trust_domain: TrustDomain, path_segments: Union[str, List[str]] = None
+    ) -> 'SpiffeId':
         """Creates SpiffeId type instance from a Trust Domain and zero or more paths.
 
         Args:
@@ -101,8 +103,8 @@ class SpiffeId(object):
             )
         return '{}://{}'.format(SPIFFE_SCHEME, self.__trust_domain.name())
 
-    # path_segments can be an array of path segments or a single string representing a path
-    def __set_path(self, path: Any) -> None:
+    # path can be an array of path segments or a single string representing a path
+    def __set_path(self, path: Union[str, List[str]]) -> None:
         if isinstance(path, list):
             self.__path = ''
             for s in path:
@@ -123,7 +125,7 @@ class SpiffeId(object):
         return self.__trust_domain == trust_domain
 
     @staticmethod
-    def parse_and_validate_uri(spiffe_id: str) -> dict:
+    def parse_and_validate_uri(spiffe_id: str) -> Dict:
         if len(spiffe_id) > SPIFFE_ID_MAXIMUM_LENGTH:
             raise ValueError(
                 'SPIFFE ID: maximum length is {} bytes.'.format(

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -27,7 +27,7 @@ class TrustDomain(object):
         spiffe://domain.test
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.__set_name(name)
 
     def __str__(self) -> str:

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -1,5 +1,5 @@
-from urllib.parse import urlparse
-from typing import Tuple, Any
+from urllib.parse import urlparse, ParseResult
+from typing import Any, cast
 
 from pyspiffe.spiffe_id import SPIFFE_SCHEME
 
@@ -56,9 +56,9 @@ class TrustDomain(object):
             )
 
         name = self.normalize(name)
-        uri = urlparse(name)
+        uri: ParseResult = urlparse(name)
         self.validate_uri(uri)
-        self.__name = uri.hostname.lower().strip()
+        self.__name = cast(str, uri.hostname).lower().strip()
 
     @staticmethod
     def normalize(name: str) -> str:
@@ -67,7 +67,7 @@ class TrustDomain(object):
         return name
 
     @staticmethod
-    def validate_uri(uri: Tuple) -> None:
+    def validate_uri(uri: ParseResult) -> None:
         if uri.scheme != SPIFFE_SCHEME:
             raise ValueError(
                 'Trust domain: invalid scheme: expected {}.'.format(SPIFFE_SCHEME)


### PR DESCRIPTION
`--ignore-missing-imports` option is used to avoid issues related to third party libraries missing type hints. In our code, this is the case for `rfc3987`. [Docs](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-ignore-missing-imports)