### PR TITLE
Fixes #42 - Pass --recreate option to tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dev: env
 ## Runs unit tests.
 test: lint
 	@echo "Running unit tests."
-	$(PIPENV_CMD) run tox
+	$(PIPENV_CMD) run tox --recreate
 
 
 ## Lint source files.


### PR DESCRIPTION
Without this option, "make test" uses a cached venv with
dependencies and packages that might be out of date.