### PR TITLE
Fixes #44. Install dependencies into tox venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ rm_env:
 dev: env
 	$(PIPENV_CMD) sync --dev && \
 	$(PIPENV_CMD) run pre-commit install
+	mkdir -p .tox
+	$(PIPENV_CMD) lock --requirements >.tox/requirements.txt
 
 
 ## Runs unit tests.

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ isolated_build = True
 
 [testenv]
 deps = pytest
+       -r{toxinidir}/.tox/requirements.txt
 commands = python -m pytest test --doctest-modules src
 
 [flake8]


### PR DESCRIPTION
I found that the tox venv doesn't have necessary dependencies specified in the Pipfile. Here's one solution, I'm not sure that it's ideal, but it seems to work.

tox doesn't support Pipfile, so this generates a
requirements.txt whenever "make dev" is run based
on the contents of the Pipfile
