### PR TITLE
Fixes #44. Update setup.py dependencies from Pipfile.lock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,26 @@
 from setuptools import setup, find_packages
 from codecs import open
-from os import path
+from os import path, environ
+from json import load
 
 DESCRIPTION = 'Python library for SPIFFE'
+
+# https://stackoverflow.com/questions/49496994/how-do-i-sync-values-in-setup-py-install-requires-with-pipfile-packages
+def locked_requirements(section):
+    # Explicitly adding an absolute path to PWD looks odd, but there's some
+    # directory shenangians that happen without it
+    with open(path.join(environ['PWD'], 'Pipfile.lock')) as pip_file:
+        pipfile_json = load(pip_file)
+
+    if section not in pipfile_json:
+        print("{0} section missing from Pipfile.lock".format(section))
+        return []
+
+    return [
+        package + detail.get('version', "")
+        for package, detail in pipfile_json[section].items()
+    ]
+
 
 here = path.abspath(path.dirname(__file__))
 
@@ -25,6 +43,6 @@ setup(
     license='Apache License Version 2.0',
     packages=find_packages(where='src', exclude=['test']),
     package_dir={'': 'src'},
-    install_requires=['rfc3987', 'pyjwt', 'cryptography', 'grpcio-tools'],
+    install_requires=locked_requirements('default'),
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This automatically updates the dependencies in setup.py
at build time using the dependencies from Pipfile.lock.

Signed-off-by: Scott Emmons <scotte@hpe.com>

This works for both `tox` as well as the wheel package, where `requires.txt` looks to contain all the dependencies.