### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+version: 2.1
+
+commands:
+  install_tox:
+    steps:
+      - run: pip install tox
+
+  run_tox:
+    parameters:
+      env:
+        default: "py36"
+        type: string
+    steps:
+      - run: tox --recreate -e <<parameters.env>>
+
+jobs:
+  test_py36:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - install_tox
+      - run_tox:
+          env: "py36"
+
+  test_py37:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - install_tox
+      - run_tox:
+          env: "py37"
+
+  test_py38:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - install_tox
+      - run_tox:
+          env: "py38"
+
+  test_py39:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - install_tox
+      - run_tox:
+          env: "py39"
+
+workflows:
+  main:
+    jobs:
+      - test_py36
+      - test_py37
+      - test_py38
+      - test_py39

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # py-spiffe Library
 
 [![Build Status](https://travis-ci.com/HewlettPackard/py-spiffe.svg?branch=master)](https://travis-ci.com/HewlettPackard/py-spiffe)
+[![CircleCI](https://circleci.com/gh/HewlettPackard/py-spiffe.svg?style=shield)](https://app.circleci.com/pipelines/github/HewlettPackard/py-spiffe)
 
 ## Overview
 Python library for SPIFFE.


### PR DESCRIPTION
This PR adds the configuration for CircleCI.

As it was previous configured with travis, this installs the library and run the tests in different python versions using Tox.
Here, we use python minor versions, e.g 3.6 (without patch) meaning it will run using the latest patch release version available at the moment. 

In this configuration, tests in different python version run in parallel and independent.