### PR TITLE
Adds lint and test coverage report jobs to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,18 +10,31 @@ commands:
       env:
         default: "py36"
         type: string
+      coveralls_token:
+        default: ""
+        type: string
     steps:
-      - run: tox --recreate -e <<parameters.env>>
-
+      - run:
+          name: run tox
+          command: |
+            COVERALLS_REPO_TOKEN=<<parameters.coveralls_token>> tox --recreate -e <<parameters.env>>
 jobs:
-  test_py36:
+  lint:
     docker:
       - image: circleci/python:3.6
     steps:
       - checkout
       - install_tox
       - run_tox:
-          env: "py36"
+          env: "lint"
+
+  test_py36:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - install_tox
+      - run_tox
 
   test_py37:
     docker:
@@ -50,10 +63,32 @@ jobs:
       - run_tox:
           env: "py39"
 
+  test_cov_report:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - install_tox
+      - run_tox:
+          env: "cov-report"
+          coveralls_token: $COVERALLS_REPO_TOKEN
+
 workflows:
   main:
     jobs:
-      - test_py36
-      - test_py37
-      - test_py38
-      - test_py39
+      - lint
+      - test_py36:
+          requires:
+              - lint
+      - test_py37:
+          requires:
+            - test_py36
+      - test_py38:
+          requires:
+            - test_py36
+      - test_py39:
+          requires:
+            - test_py36
+      - test_cov_report:
+          requires:
+            - test_py36

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__
 dist/*
 docs/_build/*
 build/*
+reports/*
+.coverage
 .tox/
 *.egg-info/
 *.egg

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.com/HewlettPackard/py-spiffe.svg?branch=master)](https://travis-ci.com/HewlettPackard/py-spiffe)
 [![CircleCI](https://circleci.com/gh/HewlettPackard/py-spiffe.svg?style=shield)](https://app.circleci.com/pipelines/github/HewlettPackard/py-spiffe)
+[![Coverage Status](https://coveralls.io/repos/github/HewlettPackard/py-spiffe/badge.svg?branch=master)](https://coveralls.io/github/HewlettPackard/py-spiffe?branch=master)
 
 ## Overview
 Python library for SPIFFE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,16 @@ exclude = '''
 )/
 '''
 
+[tool.coverage.run]
+omit = ['*/proto/*']
+source = ["pyspiffe"]
+
+[tool.coverage.paths]
+source = ["src", ".tox/*/site-packages"]
+
+[tool.coverage.html]
+directory = 'reports/unit_test'
+
 [build-system]
 requires = ["setuptools >= 50.3.2", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,37 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = lint,py36,py37,py38,py39,cov-report
 isolated_build = True
 
 [testenv]
+setenv =
+    # Suppress warn: Pipenv found itself running within a venv, so it will use that env, instead of creating its own
+    PIPENV_VERBOSITY=-1
 deps = pytest
 commands = python -m pytest test --doctest-modules src
+
+
+[testenv:lint]
+allowlist_externals=/usr/bin/make
+deps =
+    black
+    mypy
+    mypy-protobuf
+    flake8
+commands = make lint
+
+
+[testenv:cov-report]
+passenv = COVERALLS_REPO_TOKEN CIRCLECI CIRCLE_* CI_PULL_REQUEST
+allowlist_externals=/usr/bin/make
+deps =
+    pytest
+    pytest-cov
+    pytest-html
+    coveralls
+commands =
+    python -m pytest test --doctest-modules src --cov-report html --cov=pyspiffe test
+    make coveralls_call
+
 
 [flake8]
 ignore =


### PR DESCRIPTION
This PR:
- Adds the test coverage of the project to the CI and post the results to [coveralls.io](https://coveralls.io/github/HewlettPackard/py-spiffe).
- Adds make task `test_cov` to generate test coverage and it won't try to post the results to the coveralls site.
- Adds `lint` to the CI. When running on the CI it will be executed using a `tox virtual environment` but when it is run locally it continues outside of `tox` because is faster. 
- Configures Coverage Threshold for failure at [coveralls.io](https://coveralls.io/github/HewlettPackard/py-spiffe) site. Test coverage now is 91.4%. New builds will fail if test coverage is less than 90%.

Note: In order to post coverage reports to `coveralls.io`, we need to set the Env Var `COVERALLS_REPO_TOKEN` on CircleCi (is set as project level). CircleCi by default won't share Env Var with builds generated by PRs coming from forked repos. To solved this issue, the option `Project Settings -> Advance -> Pass secrets to builds from forked pull requests` is set to ON now. This is the only configuration we have so far. If in the future we have any other ENV VAR set, we should review this config.