### PR TITLE
Refactoring common functions used by X509Svid and X509Bundle

### DIFF
--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -190,4 +190,6 @@ def _write_bundle_to_file(
             for cert in x509_bundle.x509_authorities():
                 write_certificate_to_file(cert, certs_file, encoding)
     except Exception as err:
-        raise SaveX509BundleError('Error opening bundle file: {}'.format(str(err)))
+        raise SaveX509BundleError(
+            'Error writing X.509 bundle to file: {}'.format(str(err))
+        )

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -5,21 +5,22 @@ This module manages X.509 Bundle objects.
 import os
 from typing import Set
 
-import pem
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import Certificate
-from typing.io import BinaryIO
 
 from pyspiffe.bundle.x509_bundle.exceptions import (
-    ParseX509BundleError,
     X509BundleError,
-    LoadX509BundleError,
     SaveX509BundleError,
+    ParseX509BundleError,
+    LoadX509BundleError,
 )
 from pyspiffe.spiffe_id.trust_domain import TrustDomain, EMPTY_DOMAIN_ERROR
-from pyasn1.codec.der.decoder import decode
+from pyspiffe.utils.certificate_utils import (
+    parse_pem_certificates,
+    parse_der_certificates,
+    load_certificates_bytes_from_file,
+    write_certificate_to_file,
+)
 
 _BUNDLE_FILE_MODE = 0o644
 
@@ -85,8 +86,12 @@ class X509Bundle(object):
             ParseBundleError: In case the set of x509_authorities cannot be parsed from the bundle_bytes.
         """
 
-        authorities = _parse_pem_authorities(bundle_bytes)
-        return X509Bundle(trust_domain, authorities)
+        try:
+            authorities = parse_pem_certificates(bundle_bytes)
+        except Exception as e:
+            raise ParseX509BundleError(str(e))
+
+        return X509Bundle(trust_domain, set(authorities))
 
     @classmethod
     def parse_raw(cls, trust_domain: TrustDomain, bundle_bytes: bytes) -> 'X509Bundle':
@@ -104,8 +109,8 @@ class X509Bundle(object):
             ParseBundleError: In case the set of x509_authorities cannot be parsed from the bundle_bytes.
         """
 
-        authorities = _parse_der_authorities(bundle_bytes)
-        return X509Bundle(trust_domain, authorities)
+        authorities = parse_der_certificates(bundle_bytes)
+        return X509Bundle(trust_domain, set(authorities))
 
     @classmethod
     def load(
@@ -129,7 +134,10 @@ class X509Bundle(object):
             LoadBundleError: In case the set of x509_authorities cannot be parsed from the bundle_bytes.
         """
 
-        bundle_bytes = _load_bundle_bytes(bundle_path)
+        try:
+            bundle_bytes = load_certificates_bytes_from_file(bundle_path)
+        except Exception as e:
+            raise LoadX509BundleError(str(e))
 
         if encoding == serialization.Encoding.PEM:
             return cls.parse(trust_domain, bundle_bytes)
@@ -168,90 +176,18 @@ class X509Bundle(object):
                     encoding
                 )
             )
-        _write_certs_to_file(bundle_path, encoding, x509_bundle)
+        _write_bundle_to_file(bundle_path, encoding, x509_bundle)
 
 
-# Internal utility functions
-def _parse_pem_authorities(pem_bytes: bytes) -> Set[Certificate]:
-    parsed_certs = pem.parse(pem_bytes)
-    if not parsed_certs:
-        raise ParseX509BundleError('Unable to load PEM X.509 certificate')
-
-    result = set()
-    for cert in parsed_certs:
-        try:
-            x509_cert = x509.load_pem_x509_certificate(
-                cert.as_bytes(), default_backend()
-            )
-            result.add(x509_cert)
-        except Exception:
-            raise ParseX509BundleError('Unable to load PEM X.509 certificate')
-
-    return result
-
-
-def _parse_der_authorities(der_bytes: bytes) -> Set[Certificate]:
-    chain = set()
-    try:
-        leaf = x509.load_der_x509_certificate(der_bytes, default_backend())
-        chain.add(leaf)
-        _, remaining_data = decode(der_bytes)
-        while len(remaining_data) > 0:
-            cert = x509.load_der_x509_certificate(remaining_data, default_backend())
-            chain.add(cert)
-            _, remaining_data = decode(remaining_data)
-    except Exception as err:
-        raise ParseX509BundleError(str(err))
-
-    return chain
-
-
-def _load_bundle_bytes(certs_chain_path: str) -> bytes:
-    try:
-        with open(certs_chain_path, 'rb') as chain_file:
-            return chain_file.read()
-    except FileNotFoundError:
-        raise LoadX509BundleError(
-            'Certs chain file file not found: {}'.format(certs_chain_path)
-        )
-    except Exception as err:
-        raise LoadX509BundleError(
-            'Certs chain file could not be read: {}'.format(str(err))
-        )
-
-
-def _write_certs_to_file(
+def _write_bundle_to_file(
     bundle_path: str,
     encoding: serialization.Encoding,
     x509_bundle: 'X509Bundle',
 ) -> None:
     try:
-        with open(bundle_path, 'wb') as chain_file:
-            os.chmod(chain_file.name, _BUNDLE_FILE_MODE)
+        with open(bundle_path, 'wb') as certs_file:
+            os.chmod(certs_file.name, _BUNDLE_FILE_MODE)
             for cert in x509_bundle.x509_authorities():
-                _write_cert_to_file(cert, chain_file, encoding)
+                write_certificate_to_file(cert, certs_file, encoding)
     except Exception as err:
-        raise SaveX509BundleError('Error opening certs chain file: {}'.format(str(err)))
-
-
-def _write_cert_to_file(
-    authority: Certificate,
-    bundle_file: BinaryIO,
-    encoding: serialization.Encoding,
-) -> None:
-    try:
-        authority_bytes = _extract_chain_bytes(authority, encoding)
-        bundle_file.write(authority_bytes)
-    except Exception as err:
-        raise SaveX509BundleError(
-            'Error writing authority certificate to file: {}'.format(str(err))
-        )
-
-
-def _extract_chain_bytes(cert: Certificate, encoding: serialization.Encoding) -> bytes:
-    try:
-        cert_bytes = cert.public_bytes(encoding)
-    except Exception as err:
-        raise X509BundleError('Could not get bytes from object: {}'.format(str(err)))
-
-    return cert_bytes
+        raise SaveX509BundleError('Error opening bundle file: {}'.format(str(err)))

--- a/src/pyspiffe/svid/x509_svid.py
+++ b/src/pyspiffe/svid/x509_svid.py
@@ -3,35 +3,33 @@ This module manages X.509 SVID objects.
 """
 
 import os
-
-import pem
 from typing import List, Union
-from typing.io import BinaryIO
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, ed448, rsa, ec, dsa
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.x509 import Certificate
 
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import load_der_private_key
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
-
-from pyasn1.codec.der.decoder import decode
-
 from pyspiffe.svid.exceptions import (
     InvalidLeafCertificateError,
     InvalidIntermediateCertificateError,
-    ParseCertificateError,
     ParsePrivateKeyError,
     X509SvidError,
     StoreCertificateError,
     StorePrivateKeyError,
-    LoadCertificateError,
     LoadPrivateKeyError,
     normalize_exception_message,
+    ParseCertificateError,
+    LoadCertificateError,
+)
+from pyspiffe.utils.certificate_utils import (
+    parse_der_certificates,
+    parse_pem_certificates,
+    load_certificates_bytes_from_file,
+    write_certificate_to_file,
 )
 
 _UNABLE_TO_LOAD_CERTIFICATE = 'Unable to load certificate'
@@ -130,7 +128,11 @@ class X509Svid(object):
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """
 
-        chain = _parse_der_certificates(certs_chain_bytes)
+        try:
+            chain = parse_der_certificates(certs_chain_bytes)
+        except Exception as e:
+            raise ParseCertificateError(str(e))
+
         _validate_chain(chain)
 
         private_key = _parse_der_private_key(private_key_bytes)
@@ -167,7 +169,10 @@ class X509Svid(object):
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """
 
-        chain = _parse_pem_certificates(certs_chain_bytes)
+        try:
+            chain = parse_pem_certificates(certs_chain_bytes)
+        except Exception as e:
+            raise ParseCertificateError(str(e))
 
         _validate_chain(chain)
 
@@ -211,7 +216,11 @@ class X509Svid(object):
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """
 
-        chain_bytes = _load_certs_bytes(certs_chain_path)
+        try:
+            chain_bytes = load_certificates_bytes_from_file(certs_chain_path)
+        except Exception as e:
+            raise LoadCertificateError(str(e))
+
         key_bytes = _load_private_key_bytes(private_key_path)
 
         if encoding == serialization.Encoding.PEM:
@@ -260,7 +269,7 @@ class X509Svid(object):
                 )
             )
 
-        _write_certs_to_file(certs_chain_path, encoding, x509_svid)
+        _write_x509_svid_to_file(certs_chain_path, encoding, x509_svid)
 
         private_key_bytes = _extract_private_key_bytes(
             encoding, x509_svid.private_key()
@@ -268,7 +277,6 @@ class X509Svid(object):
         _write_private_key_to_file(private_key_path, private_key_bytes)
 
 
-# Internal utility methods
 def _load_private_key_bytes(private_key_path: str) -> bytes:
     try:
         with open(private_key_path, 'rb') as key_file:
@@ -280,20 +288,6 @@ def _load_private_key_bytes(private_key_path: str) -> bytes:
     except Exception as err:
         raise LoadPrivateKeyError(
             'Private key file could not be read: {}'.format(str(err))
-        )
-
-
-def _load_certs_bytes(certs_chain_path: str) -> bytes:
-    try:
-        with open(certs_chain_path, 'rb') as chain_file:
-            return chain_file.read()
-    except FileNotFoundError:
-        raise LoadCertificateError(
-            'Certs chain file file not found: {}'.format(certs_chain_path)
-        )
-    except Exception as err:
-        raise LoadCertificateError(
-            'Certs chain file could not be read: {}'.format(str(err))
         )
 
 
@@ -325,7 +319,7 @@ def _extract_private_key_bytes(
         )
 
 
-def _write_certs_to_file(
+def _write_x509_svid_to_file(
     certs_chain_path: str,
     encoding: serialization.Encoding,
     x509_svid: 'X509Svid',
@@ -334,34 +328,11 @@ def _write_certs_to_file(
         with open(certs_chain_path, 'wb') as chain_file:
             os.chmod(chain_file.name, _CERTS_FILE_MODE)
             for cert in x509_svid.cert_chain():
-                _write_cert_to_file(cert, chain_file, encoding)
+                write_certificate_to_file(cert, chain_file, encoding)
     except Exception as err:
         raise StoreCertificateError(
-            'Error opening certs chain file: {}'.format(str(err))
+            'Error opening certificates chain file: {}'.format(str(err))
         )
-
-
-def _write_cert_to_file(
-    cert: Certificate, chain_file: BinaryIO, encoding: serialization.Encoding
-) -> None:
-    try:
-        cert_bytes = _extract_cert_bytes(cert, encoding)
-        chain_file.write(cert_bytes)
-    except Exception as err:
-        raise StoreCertificateError(
-            'Error writing certs chain to file: {}'.format(str(err))
-        )
-
-
-def _extract_cert_bytes(cert: Certificate, encoding: serialization.Encoding) -> bytes:
-    try:
-        cert_bytes = cert.public_bytes(encoding)
-    except Exception as err:
-        raise X509SvidError(
-            'Could not get certs chain key bytes from object: {}'.format(str(err))
-        )
-
-    return cert_bytes
 
 
 def _parse_der_private_key(private_key_bytes: bytes) -> _PRIVATE_KEY_TYPES:
@@ -376,43 +347,6 @@ def _parse_pem_private_key(private_key_bytes: bytes) -> _PRIVATE_KEY_TYPES:
         return load_pem_private_key(private_key_bytes, None, None)
     except Exception as err:
         raise ParsePrivateKeyError(normalize_exception_message(str(err)))
-
-
-def _parse_der_certificates(chain_der_bytes: bytes) -> List[Certificate]:
-    result = []
-    try:
-        leaf = x509.load_der_x509_certificate(chain_der_bytes, default_backend())
-        result.append(leaf)
-        _, remaining_data = decode(chain_der_bytes)
-        while len(remaining_data) > 0:
-            cert = x509.load_der_x509_certificate(remaining_data, default_backend())
-            result.append(cert)
-            _, remaining_data = decode(remaining_data)
-    except Exception as err:
-        raise ParseCertificateError(normalize_exception_message(str(err)))
-
-    if len(result) < 1:
-        raise ParseCertificateError(_UNABLE_TO_LOAD_CERTIFICATE)
-
-    return result
-
-
-def _parse_pem_certificates(chain_pem_bytes: bytes) -> List[Certificate]:
-    parsed_certs = pem.parse(chain_pem_bytes)
-    if not parsed_certs:
-        raise ParseCertificateError(_UNABLE_TO_LOAD_CERTIFICATE)
-
-    result = []
-    for cert in parsed_certs:
-        try:
-            x509_cert = x509.load_pem_x509_certificate(
-                cert.as_bytes(), default_backend()
-            )
-            result.append(x509_cert)
-        except Exception:
-            raise ParseCertificateError(_UNABLE_TO_LOAD_CERTIFICATE)
-
-    return result
 
 
 def _extract_spiffe_id(cert: Certificate) -> SpiffeId:

--- a/src/pyspiffe/svid/x509_svid.py
+++ b/src/pyspiffe/svid/x509_svid.py
@@ -331,7 +331,7 @@ def _write_x509_svid_to_file(
                 write_certificate_to_file(cert, chain_file, encoding)
     except Exception as err:
         raise StoreCertificateError(
-            'Error opening certificates chain file: {}'.format(str(err))
+            'Error writing X.509 SVID to file: {}'.format(str(err))
         )
 
 

--- a/src/pyspiffe/utils/certificate_utils.py
+++ b/src/pyspiffe/utils/certificate_utils.py
@@ -1,0 +1,142 @@
+from typing import List
+
+import pem
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509 import Certificate
+from pyasn1.codec.der.decoder import decode
+from typing.io import BinaryIO
+
+from pyspiffe.utils.exceptions import X509CertificateError
+
+
+def parse_pem_certificates(pem_bytes: bytes) -> List[Certificate]:
+    """Parses a list of certificates from PEM bytes.
+
+    Args:
+        pem_bytes: List of X.509 certificates as PEM blocks bytes.
+
+    Returns:
+        A list of Certificate objects.
+
+    Raises:
+        X509CertificateError: In case the certificates cannot be parsed from the pem_bytes.
+    """
+
+    parsed_certs = pem.parse(pem_bytes)
+    if not parsed_certs:
+        raise X509CertificateError('Unable to parse PEM X.509 certificate')
+
+    result = []
+    for cert in parsed_certs:
+        try:
+            x509_cert = x509.load_pem_x509_certificate(
+                cert.as_bytes(), default_backend()
+            )
+            result.append(x509_cert)
+        except Exception:
+            raise X509CertificateError('Unable to parse PEM X.509 certificate')
+
+    return result
+
+
+def parse_der_certificates(der_bytes: bytes) -> List[Certificate]:
+    """Parses a list of certificates from ASN.1 DER bytes.
+
+    Args:
+        der_bytes: List of X.509 certificates as ASN.1 DER bytes.
+
+    Returns:
+        A list of Certificate objects.
+
+    Raises:
+        X509CertificateError: In case the certificates cannot be parsed from the der_bytes.
+    """
+
+    result = []
+    try:
+        leaf = x509.load_der_x509_certificate(der_bytes, default_backend())
+        result.append(leaf)
+        _, remaining_data = decode(der_bytes)
+        while len(remaining_data) > 0:
+            cert = x509.load_der_x509_certificate(remaining_data, default_backend())
+            result.append(cert)
+            _, remaining_data = decode(remaining_data)
+    except Exception:
+        raise X509CertificateError('Unable to parse DER X.509 certificate')
+
+    return result
+
+
+def load_certificates_bytes_from_file(certificates_file_path: str) -> bytes:
+    """Loads bytes from file path.
+
+    Args:
+        certificates_file_path: Path to the file containing the certificates.
+
+    Returns:
+        Bytes read from the file specified.
+
+    Raises:
+        X509CertificateError: In case the certificates_file cannot not be found or read.
+    """
+
+    try:
+        with open(certificates_file_path, 'rb') as certs_file:
+            return certs_file.read()
+    except FileNotFoundError:
+        raise X509CertificateError(
+            'Certificates file not found: {}'.format(certificates_file_path)
+        )
+    except Exception as err:
+        raise X509CertificateError(
+            'Certificates file could not be read: {}'.format(str(err))
+        )
+
+
+def write_certificate_to_file(
+    certificate: Certificate,
+    dest_file: BinaryIO,
+    encoding: serialization.Encoding,
+) -> None:
+    """Writes a certificate to a file.
+
+    Args:
+        certificate: Certificate object to be saved to file.
+        dest_file: BinaryIO object representing the file to be written to.
+        encoding: The serialization format to use to save the certificate.
+
+    Raises:
+        X509CertificateError: In case the certificate cannot be saved to file.
+    """
+
+    try:
+        cert_bytes = serialize_certificate(certificate, encoding)
+        dest_file.write(cert_bytes)
+    except Exception as err:
+        raise X509CertificateError(
+            'Error writing certificate to file: {}'.format(str(err))
+        )
+
+
+def serialize_certificate(
+    certificate: Certificate, encoding: serialization.Encoding
+) -> bytes:
+    """Serializes an X.509 certificate using the specified encoding.
+
+    Args:
+        certificate: Certificate object to be serialized to bytes.
+        encoding: The serialization format to use to save the certificate.
+
+    Raises:
+        X509CertificateError: In case it cannot get the bytes from the certificate object.
+    """
+    try:
+        cert_bytes = certificate.public_bytes(encoding)
+    except Exception as err:
+        raise X509CertificateError(
+            'Could not get bytes from object: {}'.format(str(err))
+        )
+
+    return cert_bytes

--- a/src/pyspiffe/utils/exceptions.py
+++ b/src/pyspiffe/utils/exceptions.py
@@ -1,0 +1,17 @@
+from pyspiffe.exceptions import PySpiffeError
+
+
+class X509CertificateError(PySpiffeError):
+    """Error raised when there is a problem processing an X.509 certificate. """
+
+    def __init__(self, message: str) -> None:
+        """Creates an instance of X509CertificateError.
+
+        Args:
+            message: Message describing the error.
+        """
+
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message

--- a/test/bundle/x509bundle/test_x509_bundle.py
+++ b/test/bundle/x509bundle/test_x509_bundle.py
@@ -1,6 +1,5 @@
-import pytest
-
 import pem
+import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -105,7 +104,7 @@ def test_parse_bundle_from_empty():
 
     assert (
         str(exception.value)
-        == 'Error parsing X.509 bundle: Unable to load PEM X.509 certificate.'
+        == 'Error parsing X.509 bundle: Unable to parse PEM X.509 certificate.'
     )
 
 
@@ -117,7 +116,7 @@ def test_parse_bundle_from_not_pem():
 
     assert (
         str(exception.value)
-        == 'Error parsing X.509 bundle: Unable to load PEM X.509 certificate.'
+        == 'Error parsing X.509 bundle: Unable to parse PEM X.509 certificate.'
     )
 
 
@@ -145,7 +144,7 @@ def test_load_bundle_non_existent_file():
 
     assert (
         str(exception.value)
-        == 'Error loading X.509 bundle: Certs chain file file not found: no-exists.'
+        == 'Error loading X.509 bundle: Certificates file not found: no-exists.'
     )
 
 

--- a/test/svid/x509svid/test_x509_svid.py
+++ b/test/svid/x509svid/test_x509_svid.py
@@ -68,7 +68,8 @@ def test_parse_raw_missing_certificate():
         X509Svid.parse_raw(chain_bytes, key_bytes)
 
     assert (
-        str(exception.value) == 'Error parsing certificate: Unable to load certificate.'
+        str(exception.value)
+        == 'Error parsing certificate: Unable to parse DER X.509 certificate.'
     )
 
 
@@ -80,7 +81,8 @@ def test_parse_missing_certificate():
         X509Svid.parse(chain_bytes, key_bytes)
 
     assert (
-        str(exception.value) == 'Error parsing certificate: Unable to load certificate.'
+        str(exception.value)
+        == 'Error parsing certificate: Unable to parse PEM X.509 certificate.'
     )
 
 
@@ -118,7 +120,8 @@ def test_parse_raw_corrupted_certificate():
         X509Svid.parse_raw(chain_bytes, key_bytes)
 
     assert (
-        str(exception.value) == 'Error parsing certificate: Unable to load certificate.'
+        str(exception.value)
+        == 'Error parsing certificate: Unable to parse DER X.509 certificate.'
     )
 
 
@@ -130,7 +133,8 @@ def test_parse_corrupted_certificate():
         X509Svid.parse(chain_bytes, key_bytes)
 
     assert (
-        str(exception.value) == 'Error parsing certificate: Unable to load certificate.'
+        str(exception.value)
+        == 'Error parsing certificate: Unable to parse PEM X.509 certificate.'
     )
 
 
@@ -290,7 +294,7 @@ def test_load_non_existent_cert_file():
 
     assert (
         str(exception.value)
-        == 'Error loading certificate from file: Certs chain file file not found: no-exists.'
+        == 'Error loading certificate from file: Certificates file not found: no-exists.'
     )
 
 

--- a/test/utils/test_certificate_utils.py
+++ b/test/utils/test_certificate_utils.py
@@ -1,0 +1,135 @@
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509 import Certificate
+
+from pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.utils.certificate_utils import (
+    parse_pem_certificates,
+    parse_der_certificates,
+    load_certificates_bytes_from_file,
+    write_certificate_to_file,
+    serialize_certificate,
+)
+from pyspiffe.utils.exceptions import X509CertificateError
+
+_EXPECTED_SPIFFE_ID = SpiffeId.parse('spiffe://example.org/service')
+_TEST_CERTS_PATH = 'test/svid/x509svid/certs/{}'
+
+
+def test_parse_der_certificates():
+    certs_bytes = _read_bytes('1-chain.der')
+
+    certs = parse_der_certificates(certs_bytes)
+
+    assert len(certs) == 2
+    assert isinstance(certs[0], Certificate)
+    assert isinstance(certs[1], Certificate)
+    assert _extract_spiffe_id(certs[0]) == _EXPECTED_SPIFFE_ID
+
+
+def test_parse_pem_certificates():
+    certs_bytes = _read_bytes('2-chain.pem')
+
+    certs = parse_pem_certificates(certs_bytes)
+
+    assert len(certs) == 2
+    assert isinstance(certs[0], Certificate)
+    assert isinstance(certs[1], Certificate)
+    assert _extract_spiffe_id(certs[0]) == _EXPECTED_SPIFFE_ID
+
+
+def test_parse_der_corrupted_certificate():
+    certs_bytes = _read_bytes('corrupted')
+
+    with pytest.raises(X509CertificateError) as exception:
+        parse_der_certificates(certs_bytes)
+
+    assert str(exception.value) == 'Unable to parse DER X.509 certificate'
+
+
+def test_parse_pem_corrupted_certificate():
+    certs_bytes = _read_bytes('corrupted')
+
+    with pytest.raises(X509CertificateError) as exception:
+        parse_pem_certificates(certs_bytes)
+
+    assert str(exception.value) == 'Unable to parse PEM X.509 certificate'
+
+
+def test_load_certificates_bytes_from_pem_file():
+    certs_file_path = _TEST_CERTS_PATH.format('2-chain.pem')
+
+    certs_bytes = load_certificates_bytes_from_file(certs_file_path)
+    certs = parse_pem_certificates(certs_bytes)
+
+    assert len(certs) == 2
+    assert isinstance(certs[0], Certificate)
+    assert isinstance(certs[1], Certificate)
+    assert _extract_spiffe_id(certs[0]) == _EXPECTED_SPIFFE_ID
+
+
+def test_load_certificates_bytes_from_der_file():
+    certs_file_path = _TEST_CERTS_PATH.format('1-chain.der')
+
+    certs_bytes = load_certificates_bytes_from_file(certs_file_path)
+    certs = parse_der_certificates(certs_bytes)
+
+    assert len(certs) == 2
+    assert isinstance(certs[0], Certificate)
+    assert isinstance(certs[1], Certificate)
+    assert _extract_spiffe_id(certs[0]) == _EXPECTED_SPIFFE_ID
+
+
+def test_save_certificate_to_file_as_pem(tmpdir):
+    certs_file_path = _TEST_CERTS_PATH.format('1-chain.der')
+    certs_bytes = load_certificates_bytes_from_file(certs_file_path)
+    certs = parse_der_certificates(certs_bytes)
+
+    # temp files to store the certs and private_key
+    cert_dest_file = tmpdir.join('cert.pem')
+
+    write_certificate_to_file(certs[0], cert_dest_file, serialization.Encoding.PEM)
+
+    certs_bytes = load_certificates_bytes_from_file(cert_dest_file)
+    saved_cert = parse_pem_certificates(certs_bytes)[0]
+
+    assert isinstance(saved_cert, Certificate)
+    assert _extract_spiffe_id(saved_cert) == _EXPECTED_SPIFFE_ID
+
+
+def test_extract_der_bytes_from_certificate():
+    certs_bytes = _read_bytes('1-chain.der')
+    cert = parse_der_certificates(certs_bytes)[0]
+
+    cert_bytes = serialize_certificate(cert, serialization.Encoding.DER)
+
+    cert = parse_der_certificates(cert_bytes)[0]
+
+    assert isinstance(cert, Certificate)
+    assert _extract_spiffe_id(cert) == _EXPECTED_SPIFFE_ID
+
+
+def test_extract_pem_bytes_from_certificate():
+    certs_bytes = _read_bytes('2-chain.pem')
+    cert = parse_pem_certificates(certs_bytes)[0]
+
+    cert_bytes = serialize_certificate(cert, serialization.Encoding.PEM)
+    cert = parse_pem_certificates(cert_bytes)[0]
+
+    assert isinstance(cert, Certificate)
+    assert _extract_spiffe_id(cert) == _EXPECTED_SPIFFE_ID
+
+
+def _read_bytes(filename):
+    path = _TEST_CERTS_PATH.format(filename)
+    with open(path, 'rb') as file:
+        return file.read()
+
+
+def _extract_spiffe_id(cert: Certificate) -> SpiffeId:
+    ext = cert.extensions.get_extension_for_oid(
+        x509.ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+    )
+    sans = ext.value.get_values_for_type(x509.UniformResourceIdentifier)
+    return SpiffeId.parse(sans[0])


### PR DESCRIPTION
There are several functions in `X509Svid` and `X509Bundle` that are duplicated, as both types were implemented in parallel. This PR refactors the common functionality and moves it to an utility module to handle certificates. Also took the opportunity to improve method and parameters names and error messages. 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>