### PR TITLE
Enforce immutability and thread-safety on X.509 SVIDs and Bundle objects

### DIFF
--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -57,9 +57,9 @@ class X509Bundle(object):
             self._x509_authorities = set()
 
     def __eq__(self, o: object) -> bool:
+        if not isinstance(o, X509Bundle):
+            return False
         with self.lock:
-            if not isinstance(o, X509Bundle):
-                return False
             return (
                 self._trust_domain.__eq__(o._trust_domain)
                 and self._x509_authorities == o._x509_authorities
@@ -76,7 +76,8 @@ class X509Bundle(object):
 
     def add_authority(self, x509_authority: Certificate) -> None:
         """Adds an X.509 authority to the bundle. """
-        self._x509_authorities.add(copy.copy(x509_authority))
+        with self.lock:
+            self._x509_authorities.add(copy.copy(x509_authority))
 
     def remove_authority(self, x509_authority: Certificate) -> None:
         """Removes an X.509 authority from the bundle. """

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -51,7 +51,7 @@ class X509Bundle(object):
             raise X509BundleError(EMPTY_DOMAIN_ERROR)
         self._trust_domain = trust_domain
 
-        if x509_authorities is not None:
+        if x509_authorities:
             self._x509_authorities = x509_authorities.copy()
         else:
             self._x509_authorities = set()
@@ -99,7 +99,7 @@ class X509Bundle(object):
 
         Raises:
             X509BundleError: In case the trust_domain is empty.
-            ParseBundleError: In case the set of x509_authorities cannot be parsed from the bundle_bytes.
+            ParseX509BundleError: In case the set of x509_authorities cannot be parsed from the bundle_bytes.
         """
 
         try:

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -1,7 +1,6 @@
 """
 This module manages X.509 Bundle objects.
 """
-import copy
 import os
 import threading
 from typing import Set
@@ -73,7 +72,7 @@ class X509Bundle(object):
     def x509_authorities(self) -> Set[Certificate]:
         """Returns a copy of set of X.509 authorities in the bundle. """
         with self.lock:
-            return copy.copy(self._x509_authorities)
+            return self._x509_authorities.copy()
 
     def add_authority(self, x509_authority: Certificate) -> None:
         """Adds an X.509 authority to the bundle. """

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -72,12 +72,11 @@ class X509Bundle(object):
     def x509_authorities(self) -> Set[Certificate]:
         """Returns a copy of set of X.509 authorities in the bundle. """
         with self.lock:
-            return copy.deepcopy(self._x509_authorities)
+            return copy.copy(self._x509_authorities)
 
     def add_authority(self, x509_authority: Certificate) -> None:
         """Adds an X.509 authority to the bundle. """
-        with self.lock:
-            self._x509_authorities.add(copy.copy(x509_authority))
+        self._x509_authorities.add(copy.copy(x509_authority))
 
     def remove_authority(self, x509_authority: Certificate) -> None:
         """Removes an X.509 authority from the bundle. """

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -52,8 +52,9 @@ class X509Bundle(object):
             raise X509BundleError(EMPTY_DOMAIN_ERROR)
         self._trust_domain = trust_domain
 
-        self._x509_authorities = copy.deepcopy(x509_authorities)
-        if not self._x509_authorities:
+        if x509_authorities is not None:
+            self._x509_authorities = x509_authorities.copy()
+        else:
             self._x509_authorities = set()
 
     def __eq__(self, o: object) -> bool:
@@ -77,7 +78,7 @@ class X509Bundle(object):
     def add_authority(self, x509_authority: Certificate) -> None:
         """Adds an X.509 authority to the bundle. """
         with self.lock:
-            self._x509_authorities.add(copy.copy(x509_authority))
+            self._x509_authorities.add(x509_authority)
 
     def remove_authority(self, x509_authority: Certificate) -> None:
         """Removes an X.509 authority from the bundle. """

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -1,8 +1,9 @@
 """
 This module manages X.509 Bundle objects.
 """
-
+import copy
 import os
+import threading
 from typing import Set
 
 from cryptography.hazmat.primitives import serialization
@@ -44,31 +45,46 @@ class X509Bundle(object):
         Raises:
             X509BundleError: In case the trust_domain is empty.
         """
+
+        self.lock = threading.Lock()
+
         if not trust_domain:
             raise X509BundleError(EMPTY_DOMAIN_ERROR)
         self._trust_domain = trust_domain
 
-        self._x509_authorities = x509_authorities
+        self._x509_authorities = copy.deepcopy(x509_authorities)
         if not self._x509_authorities:
             self._x509_authorities = set()
+
+    def __eq__(self, o: object) -> bool:
+        with self.lock:
+            if not isinstance(o, X509Bundle):
+                return False
+            return (
+                self._trust_domain.__eq__(o._trust_domain)
+                and self._x509_authorities == o._x509_authorities
+            )
 
     def trust_domain(self) -> TrustDomain:
         """Returns the trust domain of the bundle. """
         return self._trust_domain
 
     def x509_authorities(self) -> Set[Certificate]:
-        """Returns the set of X.509 authorities in the bundle. """
-        return self._x509_authorities
+        """Returns a copy of set of X.509 authorities in the bundle. """
+        with self.lock:
+            return copy.deepcopy(self._x509_authorities)
 
     def add_authority(self, x509_authority: Certificate) -> None:
         """Adds an X.509 authority to the bundle. """
-        self._x509_authorities.add(x509_authority)
+        with self.lock:
+            self._x509_authorities.add(copy.copy(x509_authority))
 
     def remove_authority(self, x509_authority: Certificate) -> None:
         """Removes an X.509 authority from the bundle. """
-        if not self._x509_authorities:
-            return
-        self._x509_authorities.remove(x509_authority)
+        with self.lock:
+            if not self._x509_authorities:
+                return
+            self._x509_authorities.remove(x509_authority)
 
     @classmethod
     def parse(cls, trust_domain: TrustDomain, bundle_bytes: bytes) -> 'X509Bundle':

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -2,6 +2,7 @@
 This module manages X509BundleSet objects.
 """
 import copy
+import threading
 from typing import List, Optional, Dict
 
 from pyspiffe.bundle.x509_bundle.x509_bundle import X509Bundle
@@ -20,6 +21,7 @@ class X509BundleSet(object):
             bundles_map: A map object of X509Bundle objects keyed by TrustDomain to initialize the X509BundleSet.
         """
 
+        self.lock = threading.Lock()
         self._bundles = copy.copy(bundles_map)
 
     def put(self, bundle: X509Bundle) -> None:
@@ -28,7 +30,8 @@ class X509BundleSet(object):
         Args:
             bundle: The new X509Bundle to put into the set.
         """
-        self._bundles[bundle.trust_domain()] = bundle
+        with self.lock:
+            self._bundles[bundle.trust_domain()] = bundle
 
     def get_x509_bundle_for_trust_domain(
         self, trust_domain: TrustDomain
@@ -42,7 +45,8 @@ class X509BundleSet(object):
             A X509Bundle object for the given TrustDomain.
             None if the TrustDomain is not found in the set.
         """
-        return self._bundles.get(trust_domain)
+        with self.lock:
+            return self._bundles.get(trust_domain)
 
     @classmethod
     def of(cls, bundle_list: List[X509Bundle]) -> 'X509BundleSet':

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -22,7 +22,7 @@ class X509BundleSet(object):
 
         self.lock = threading.Lock()
 
-        if bundles_map is not None:
+        if bundles_map:
             self._bundles = bundles_map.copy()
         else:
             self._bundles = dict()

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -2,7 +2,6 @@
 This module manages X509BundleSet objects.
 """
 import copy
-import threading
 from typing import List, Optional, Dict
 
 from pyspiffe.bundle.x509_bundle.x509_bundle import X509Bundle
@@ -21,7 +20,6 @@ class X509BundleSet(object):
             bundles_map: A map object of X509Bundle objects keyed by TrustDomain to initialize the X509BundleSet.
         """
 
-        self.lock = threading.Lock()
         self._bundles = copy.copy(bundles_map)
 
     def put(self, bundle: X509Bundle) -> None:
@@ -30,8 +28,7 @@ class X509BundleSet(object):
         Args:
             bundle: The new X509Bundle to put into the set.
         """
-        with self.lock:
-            self._bundles[bundle.trust_domain()] = bundle
+        self._bundles[bundle.trust_domain()] = bundle
 
     def get_x509_bundle_for_trust_domain(
         self, trust_domain: TrustDomain
@@ -45,8 +42,7 @@ class X509BundleSet(object):
             A X509Bundle object for the given TrustDomain.
             None if the TrustDomain is not found in the set.
         """
-        with self.lock:
-            return self._bundles.get(trust_domain)
+        return self._bundles.get(trust_domain)
 
     @classmethod
     def of(cls, bundle_list: List[X509Bundle]) -> 'X509BundleSet':

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -1,8 +1,9 @@
 """
 This module manages X509BundleSet objects.
 """
-
-from typing import Mapping, List, Optional
+import copy
+import threading
+from typing import List, Optional, Dict
 
 from pyspiffe.bundle.x509_bundle.x509_bundle import X509Bundle
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
@@ -13,18 +14,15 @@ __all__ = ['X509Bundle']
 class X509BundleSet(object):
     """X509BundleSet is a set of X509Bundles objects, keyed by trust domain."""
 
-    def __init__(self, bundles_map: Mapping[TrustDomain, X509Bundle]) -> None:
+    def __init__(self, bundles_map: Dict[TrustDomain, X509Bundle]) -> None:
         """Creates a new initialized X509BundleSet with the given X509Bundle objects keyed by TrustDomain.
 
         Args:
             bundles_map: A map object of X509Bundle objects keyed by TrustDomain to initialize the X509BundleSet.
         """
 
-        # create and initialize a dict, so it can be updated (as Mapping doesn't define __setitem__)
-        bundles = {}
-        for td, bundle in bundles_map.items():
-            bundles[td] = bundle
-        self._bundles = bundles
+        self.lock = threading.Lock()
+        self._bundles = copy.copy(bundles_map)
 
     def put(self, bundle: X509Bundle) -> None:
         """Adds a new X509Bundle object or replace an existing one into the set.
@@ -32,7 +30,8 @@ class X509BundleSet(object):
         Args:
             bundle: The new X509Bundle to put into the set.
         """
-        self._bundles[bundle.trust_domain()] = bundle
+        with self.lock:
+            self._bundles[bundle.trust_domain()] = bundle
 
     def get_x509_bundle_for_trust_domain(
         self, trust_domain: TrustDomain
@@ -46,7 +45,8 @@ class X509BundleSet(object):
             A X509Bundle object for the given TrustDomain.
             None if the TrustDomain is not found in the set.
         """
-        return self._bundles.get(trust_domain)
+        with self.lock:
+            return self._bundles.get(trust_domain)
 
     @classmethod
     def of(cls, bundle_list: List[X509Bundle]) -> 'X509BundleSet':

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle_set.py
@@ -1,7 +1,6 @@
 """
 This module manages X509BundleSet objects.
 """
-import copy
 import threading
 from typing import List, Optional, Dict
 
@@ -22,7 +21,11 @@ class X509BundleSet(object):
         """
 
         self.lock = threading.Lock()
-        self._bundles = copy.copy(bundles_map)
+
+        if bundles_map is not None:
+            self._bundles = bundles_map.copy()
+        else:
+            self._bundles = dict()
 
     def put(self, bundle: X509Bundle) -> None:
         """Adds a new X509Bundle object or replace an existing one into the set.

--- a/src/pyspiffe/svid/x509_svid.py
+++ b/src/pyspiffe/svid/x509_svid.py
@@ -1,7 +1,6 @@
 """
 This module manages X.509 SVID objects.
 """
-import copy
 import os
 from typing import List, Union
 
@@ -87,7 +86,7 @@ class X509Svid(object):
 
     def cert_chain(self) -> List[Certificate]:
         """Returns the X.509 chain of certificates."""
-        return copy.copy(self._cert_chain)
+        return self._cert_chain.copy()
 
     def private_key(self) -> _PRIVATE_KEY_TYPES:
         """Returns the private key."""

--- a/src/pyspiffe/svid/x509_svid.py
+++ b/src/pyspiffe/svid/x509_svid.py
@@ -1,7 +1,7 @@
 """
 This module manages X.509 SVID objects.
 """
-
+import copy
 import os
 from typing import List, Union
 
@@ -87,7 +87,7 @@ class X509Svid(object):
 
     def cert_chain(self) -> List[Certificate]:
         """Returns the X.509 chain of certificates."""
-        return self._cert_chain
+        return copy.copy(self._cert_chain)
 
     def private_key(self) -> _PRIVATE_KEY_TYPES:
         """Returns the private key."""

--- a/test/bundle/x509bundle/test_x509_bundle.py
+++ b/test/bundle/x509bundle/test_x509_bundle.py
@@ -232,6 +232,10 @@ def test_add_and_remove_authority():
         pem_certs[1].as_bytes(), default_backend()
     )
 
+    # adding an object to the returned set, as it is a copy, it doesn't change the bundle
+    bundle.x509_authorities().add(x509_cert_1)
+    assert len(bundle.x509_authorities()) == 0
+
     bundle.add_authority(x509_cert_1)
     bundle.add_authority(x509_cert_2)
     assert len(bundle.x509_authorities()) == 2

--- a/test/bundle/x509bundle/test_x509_bundle_set.py
+++ b/test/bundle/x509bundle/test_x509_bundle_set.py
@@ -18,6 +18,8 @@ def test_create_new_x509_bundle_set():
     x509_bundle_set = X509BundleSet(bundles)
 
     assert len(x509_bundle_set._bundles) == 2
+    # check that the bundle map was copied
+    assert x509_bundle_set._bundles is not bundles
 
     found_bundle = x509_bundle_set.get_x509_bundle_for_trust_domain(trust_domain_1)
     assert found_bundle == bundle_1

--- a/test/svid/x509svid/test_x509_svid.py
+++ b/test/svid/x509svid/test_x509_svid.py
@@ -386,6 +386,15 @@ def test_load_non_supported_encoding():
     )
 
 
+def test_get_chain_returns_a_copy():
+    chain_bytes = read_bytes('1-chain.der')
+    key_bytes = read_bytes('1-key.der')
+
+    x509_svid = X509Svid.parse_raw(chain_bytes, key_bytes)
+
+    assert x509_svid.cert_chain() is not x509_svid._cert_chain
+
+
 def read_bytes(filename):
     path = _TEST_CERTS_PATH.format(filename)
     with open(path, 'rb') as file:


### PR DESCRIPTION
This PR makes the types `X509Svid`, `X509Bundle`, and `X509BundleSet` immutable and thread-safe by making the getters returns copies of the internal collections, making the constructors deepcopy the collections passed as arguments, and making the `add` and `remove` methods use a Lock to prevent data-races.

Once this PR gets the approval of the team, there will remain to make the same kind of adaptations to the other types (`JWTBundle`, etc)

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>