### PR TITLE
Implements ValidateJWTSVID(). 

### DIFF
--- a/src/pyspiffe/svid/jwt_svid_validator.py
+++ b/src/pyspiffe/svid/jwt_svid_validator.py
@@ -3,7 +3,7 @@ This module manages the validations of JWT tokens.
 """
 
 import datetime
-from typing import List, Set, Dict, Any
+from typing import List, Dict, Any
 from calendar import timegm
 
 from pyspiffe.svid import INVALID_INPUT_ERROR
@@ -75,13 +75,13 @@ class JwtSvidValidator(object):
             raise InvalidTypeError(typ)
 
     def validate_claims(
-        self, payload: Dict[str, Any], expected_audience: Set[str]
+        self, payload: Dict[str, Any], expected_audience: List[str]
     ) -> None:
         """Validates payload for required claims (aud, exp, sub).
 
         Args:
             payload: Token payload.
-            expected_audience: Audience as a Set of strings used to validate the 'aud' claim.
+            expected_audience: Audience as a list of strings used to validate the 'aud' claim.
 
         Returns:
             None
@@ -116,7 +116,7 @@ class JwtSvidValidator(object):
             raise TokenExpiredError()
 
     def _validate_aud(
-        self, audience_claim: List[str], expected_audience: Set[str]
+        self, audience_claim: List[str], expected_audience: List[str]
     ) -> None:
         """Verifies if expected_audience is present in audience_claim. The aud claim MUST be present.
 

--- a/src/pyspiffe/workloadapi/exceptions.py
+++ b/src/pyspiffe/workloadapi/exceptions.py
@@ -61,3 +61,17 @@ class FetchJwtSvidError(WorkloadApiError):
             additional_information: Additional information about the error.
         """
         super().__init__(self._MESSAGE.format(additional_information))
+
+
+class ValidateJwtSvidError(WorkloadApiError):
+    """Error raised when a JWT-SVID cannot be validated by the Workload API."""
+
+    _MESSAGE = 'JWT SVID is not valid: {}.'
+
+    def __init__(self, additional_information: str = 'none') -> None:
+        """Creates an instance of ValidateJwtSvidError.
+
+        Args:
+            additional_information: Additional information about the error.
+        """
+        super().__init__(self._MESSAGE.format(additional_information))

--- a/test/svid/jwtsvid/test_jwt_svid.py
+++ b/test/svid/jwtsvid/test_jwt_svid.py
@@ -7,7 +7,6 @@ from cryptography.hazmat.backends import default_backend
 from pyspiffe.svid import INVALID_INPUT_ERROR
 from pyspiffe.svid.jwt_svid import JwtSvid
 from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
-from pyspiffe.spiffe_id.trust_domain import TrustDomain
 from pyspiffe.svid.exceptions import (
     TokenExpiredError,
     JwtSvidError,
@@ -15,17 +14,17 @@ from pyspiffe.svid.exceptions import (
     MissingClaimError,
 )
 from pyspiffe.bundle.jwt_bundle.exceptions import AuthorityNotFoundError
-from test.svid.test_utils import get_keys_pems, create_jwt
-
-# parse and validate tests initializers
-AUDIENCE = ['spire', 'test', 'valid']
-SPIFFE_ID = 'spiffe://test.orgcom/'
-RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-RSA_KEY_PEM, _ = get_keys_pems(RSA_KEY)
-JWT_BUNDLE = JwtBundle(TrustDomain('test.orgcom'), {'kid1': RSA_KEY.public_key()})
-EXPIRY = timegm(
-    (datetime.datetime.utcnow() + datetime.timedelta(hours=4)).utctimetuple()
+from test.svid.test_utils import (
+    get_keys_pems,
+    create_jwt,
+    DEFAULT_SPIFFE_ID,
+    DEFAULT_AUDIENCE,
+    DEFAULT_KEY,
+    DEFAULT_TRUST_DOMAIN,
+    DEFAULT_EXPIRY,
 )
+
+JWT_BUNDLE = JwtBundle(DEFAULT_TRUST_DOMAIN, {'kid1': DEFAULT_KEY.public_key()})
 
 
 """
@@ -110,7 +109,7 @@ def test_parse_insecure_invalid_input(test_input_token, test_input_audience, exp
                 'secret',
                 headers={'alg': 'PS512', 'typ': 'JOSE'},
             ),
-            ["spire"],
+            ['spire'],
             str(TokenExpiredError()),
         ),  # expired token
     ],
@@ -127,11 +126,11 @@ def test_parse_insecure_invalid_claims(test_input_token, test_input_audience, ex
     [
         (
             'eyJhbGciOiJFUzI1NiIsImtpZCI6Imd1eTdsOWZSQzhkQW1IUmFtaFpQbktRa3lId2FHQzR0IiwidHlwIjoiSldUIn0.eyJhdWQiOlsib3RoZXItc2VydmljZSJdLCJleHAiOjE2MTIyOTAxODMsImlhdCI6MTYxMjI4OTg4Mywic3ViIjoic3hthrtmZlOi8vZXhhbXBsZS5vcmcvc2VydmljZSJ9.W7CLQvYVBQ8Zg3ELcuB1K9hE4I9wyCMB_8PJTZXbjnlMBcgd0VDbSm5OjoqcGQF975eaVl_AdkryJ_lzxsEQ4A',
-            ["spire"],
+            ['spire'],
         ),  # middle
         (
             'errJhbGciOiJFUzI1NiIsImtpZCI6Imd1eTdsOWZSQzhkQW1IUmFtaFpQbktRa3lId2FHQzR0IiwidHlwIjoiSldUIn0.eyJhdWQiOlsib3RoZXItc2VydmljZSJdLCJleHAiOjE2MTIyOTAxODMsImlhdCI6MTYxMjI4OTg4Mywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvc2VydmljZSJ9.W7CLQvYVBQ8Zg3ELcuB1K9hE4I9wyCMB_8PJTZXbjnlMBcgd0VDbSm5OjoqcGQF975eaVl_AdkryJ_lzxsEQ4A',
-            ["spire"],
+            ['spire'],
         ),  # first
     ],
 )
@@ -164,7 +163,7 @@ def test_parse_insecure_invalid_token(test_input_token, test_input_audience):
             jwt.encode(
                 {
                     'aud': ['spire', 'test', 'valid'],
-                    'sub': 'spiffe://test.orgcom.br/',
+                    'sub': 'spiffe://test.com.br/',
                     'exp': timegm(
                         (
                             datetime.datetime.utcnow() + datetime.timedelta(hours=1)
@@ -174,8 +173,8 @@ def test_parse_insecure_invalid_token(test_input_token, test_input_audience):
                 'secret key',
                 headers={'alg': 'PS384', 'typ': 'JOSE'},
             ),
-            ['spire', 'test'],
-            "spiffe://test.orgcom.br/",
+            {'spire', 'test'},
+            "spiffe://test.com.br/",
         ),
     ],
 )
@@ -219,7 +218,7 @@ def test_parse_and_validate_invalid_parameters(
 
 
 def test_parse_and_validate_invalid_missing_kid_header():
-    token = create_jwt(RSA_KEY_PEM, '', 'RS256', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt(kid='')
 
     with pytest.raises(InvalidTokenError) as exception:
         JwtSvid.parse_and_validate(token, JWT_BUNDLE, ['spire'])
@@ -227,16 +226,16 @@ def test_parse_and_validate_invalid_missing_kid_header():
 
 
 def test_parse_and_validate_invalid_missing_sub():
-    token = create_jwt(RSA_KEY_PEM, 'kid1', 'RS256', AUDIENCE, '', EXPIRY)
+    token = create_jwt(spiffe_id='')
 
     with pytest.raises(InvalidTokenError) as exception:
-        JwtSvid.parse_and_validate(token, JWT_BUNDLE, 'spire')
+        JwtSvid.parse_and_validate(token, JWT_BUNDLE, ['spire'])
     assert str(exception.value) == 'SPIFFE ID cannot be empty.'
 
 
 def test_parse_and_validate_invalid_missing_kid():
     key_id = 'kid10'
-    token = create_jwt(RSA_KEY_PEM, key_id, 'RS256', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt(kid=key_id)
 
     with pytest.raises(AuthorityNotFoundError) as exception:
         JwtSvid.parse_and_validate(token, JWT_BUNDLE, ['spire'])
@@ -246,10 +245,10 @@ def test_parse_and_validate_invalid_missing_kid():
 def test_parse_and_validate_invalid_kid_mismatch():
     rsa_key2 = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     jwt_bundle = JwtBundle(
-        TrustDomain('test.orgcom'),
-        {'kid1': RSA_KEY.public_key(), 'kid10': rsa_key2.public_key()},
+        DEFAULT_TRUST_DOMAIN,
+        {'kid1': DEFAULT_KEY.public_key(), 'kid10': rsa_key2.public_key()},
     )
-    token = create_jwt(RSA_KEY_PEM, 'kid10', 'RS256', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt(kid='kid10')
 
     with pytest.raises(InvalidTokenError) as exception:
         JwtSvid.parse_and_validate(token, jwt_bundle, ['spire'])
@@ -257,45 +256,45 @@ def test_parse_and_validate_invalid_kid_mismatch():
 
 
 def test_parse_and_validate_valid_token_RSA():
-    token = create_jwt(RSA_KEY_PEM, 'kid1', 'RS256', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt()
     jwt_svid = JwtSvid.parse_and_validate(token, JWT_BUNDLE, ['spire'])
-    assert jwt_svid.audience == AUDIENCE
-    assert str(jwt_svid.spiffe_id) == SPIFFE_ID
-    assert jwt_svid.expiry == EXPIRY
+    assert jwt_svid.audience == DEFAULT_AUDIENCE
+    assert str(jwt_svid.spiffe_id) == DEFAULT_SPIFFE_ID
+    assert jwt_svid.expiry == DEFAULT_EXPIRY
     assert jwt_svid.token == token
 
 
 def test_parse_and_validate_valid_token_EC():
     ec_key = ec.generate_private_key(ec.SECP384R1(), default_backend())
-    jwt_bundle = JwtBundle(TrustDomain('test.orgcom'), {'kid_ec': ec_key.public_key()})
+    jwt_bundle = JwtBundle(DEFAULT_TRUST_DOMAIN, {'kid_ec': ec_key.public_key()})
 
     ec_key_pem, _ = get_keys_pems(ec_key)
-    token = create_jwt(ec_key_pem, 'kid_ec', 'ES512', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt(ec_key_pem, 'kid_ec', alg='ES512')
     jwt_svid = JwtSvid.parse_and_validate(token, jwt_bundle, ['spire'])
-    assert jwt_svid.audience == AUDIENCE
-    assert str(jwt_svid.spiffe_id) == SPIFFE_ID
-    assert jwt_svid.expiry == EXPIRY
+    assert jwt_svid.audience == DEFAULT_AUDIENCE
+    assert str(jwt_svid.spiffe_id) == DEFAULT_SPIFFE_ID
+    assert jwt_svid.expiry == DEFAULT_EXPIRY
     assert jwt_svid.token == token
 
 
 def test_parse_and_validate_valid_token_multiple_keys_bundle():
     ec_key = ec.generate_private_key(ec.SECP521R1(), default_backend())
     jwt_bundle = JwtBundle(
-        TrustDomain('test.orgcom'),
-        {'kid_rsa': RSA_KEY.public_key(), 'kid_ec': ec_key.public_key()},
+        DEFAULT_TRUST_DOMAIN,
+        {'kid_rsa': DEFAULT_KEY.public_key(), 'kid_ec': ec_key.public_key()},
     )
     ec_key_pem, _ = get_keys_pems(ec_key)
 
-    token = create_jwt(ec_key_pem, 'kid_ec', 'ES512', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token = create_jwt(ec_key_pem, kid='kid_ec', alg='ES512')
     jwt_svid1 = JwtSvid.parse_and_validate(token, jwt_bundle, ['spire'])
-    assert jwt_svid1.audience == AUDIENCE
-    assert str(jwt_svid1.spiffe_id) == SPIFFE_ID
-    assert jwt_svid1.expiry == EXPIRY
+    assert jwt_svid1.audience == DEFAULT_AUDIENCE
+    assert str(jwt_svid1.spiffe_id) == DEFAULT_SPIFFE_ID
+    assert jwt_svid1.expiry == DEFAULT_EXPIRY
     assert jwt_svid1.token == token
 
-    token2 = create_jwt(RSA_KEY_PEM, 'kid_rsa', 'RS256', AUDIENCE, SPIFFE_ID, EXPIRY)
+    token2 = create_jwt(kid='kid_rsa')
     jwt_svid2 = JwtSvid.parse_and_validate(token2, jwt_bundle, ['spire'])
-    assert jwt_svid2.audience == AUDIENCE
-    assert str(jwt_svid2.spiffe_id) == SPIFFE_ID
-    assert jwt_svid2.expiry == EXPIRY
+    assert jwt_svid2.audience == DEFAULT_AUDIENCE
+    assert str(jwt_svid2.spiffe_id) == DEFAULT_SPIFFE_ID
+    assert jwt_svid2.expiry == DEFAULT_EXPIRY
     assert jwt_svid2.token == token2

--- a/test/svid/jwtsvid/test_jwt_svid_validator.py
+++ b/test/svid/jwtsvid/test_jwt_svid_validator.py
@@ -52,7 +52,7 @@ from pyspiffe.svid.exceptions import (
         ),
     ],
 )
-def test_invalid_input_validate_claims(test_input_claim, test_input_audience, expected):
+def test_validate_claims_invalid_input(test_input_claim, test_input_audience, expected):
     with pytest.raises(ValueError) as exception:
         JwtSvidValidator().validate_claims(test_input_claim, test_input_audience)
 
@@ -129,7 +129,7 @@ def test_invalid_input_validate_claims(test_input_claim, test_input_audience, ex
         ),
     ],
 )
-def test_invalid_aud_validate_claim(test_input_claim, test_input_audience, expected):
+def test_validate_claims_invalid_aud(test_input_claim, test_input_audience, expected):
     with pytest.raises(InvalidClaimError) as exception:
         JwtSvidValidator().validate_claims(test_input_claim, test_input_audience)
 
@@ -185,7 +185,7 @@ def test_invalid_aud_validate_claim(test_input_claim, test_input_audience, expec
         ),
     ],
 )
-def test_token_expired_validate_claim(test_input_claim, test_input_audience):
+def test_validate_claims_token_expired(test_input_claim, test_input_audience):
     with pytest.raises(TokenExpiredError) as exception:
         JwtSvidValidator().validate_claims(test_input_claim, test_input_audience)
     assert str(exception.value) == str(TokenExpiredError())
@@ -211,7 +211,7 @@ def test_token_expired_validate_claim(test_input_claim, test_input_audience):
         ({}, set(), str(MissingClaimError('aud'))),
     ],
 )
-def test_missing_required_claim_validate_claims(
+def test_validate_claims_missing_required_claim(
     test_input_claim, test_input_audience, expected
 ):
     with pytest.raises(MissingClaimError) as exception:
@@ -261,8 +261,9 @@ def test_missing_required_claim_validate_claims(
         ),
     ],
 )
-def test_valid_input_validate_claims(test_input_claim, test_input_audience):
+def test_validate_claims_valid_input(test_input_claim, test_input_audience):
     JwtSvidValidator().validate_claims(test_input_claim, test_input_audience)
+
     assert True
 
 

--- a/test/workloadapi/test_default_workload_api_client.py
+++ b/test/workloadapi/test_default_workload_api_client.py
@@ -4,6 +4,7 @@ import pytest
 from pyspiffe.workloadapi.default_workload_api_client import DefaultWorkloadApiClient
 
 SPIFFE_SOCKET_ENV = 'SPIFFE_ENDPOINT_SOCKET'
+WORKLOAD_API_CLIENT = DefaultWorkloadApiClient('unix:///dummy.path')
 
 
 # No SPIFFE_ENDPOINT_SOCKET, and no path passed, raises exception

--- a/test/workloadapi/test_default_workload_api_client_fetch_x509.py
+++ b/test/workloadapi/test_default_workload_api_client_fetch_x509.py
@@ -5,11 +5,10 @@ from cryptography.x509 import Certificate
 from pyspiffe.proto.spiffe import workload_pb2
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
-from pyspiffe.workloadapi.default_workload_api_client import DefaultWorkloadApiClient
 from pyspiffe.workloadapi.exceptions import FetchX509SvidError, FetchX509BundleError
 from test.utils.utils import read_file_bytes
+from test.workloadapi.test_default_workload_api_client import WORKLOAD_API_CLIENT
 
-_WORKLOAD_API_CLIENT = DefaultWorkloadApiClient('unix:///dummy.path')
 _TEST_CERTS_PATH = 'test/svid/x509svid/certs/{}'
 _TEST_BUNDLE_PATH = 'test/bundle/x509bundle/certs/{}'
 _CHAIN1 = read_file_bytes(_TEST_CERTS_PATH.format('1-chain.der'))
@@ -22,7 +21,7 @@ _CORRUPTED = read_file_bytes(_TEST_CERTS_PATH.format('corrupted'))
 
 
 def test_fetch_x509_svid_success(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -43,7 +42,7 @@ def test_fetch_x509_svid_success(mocker):
         )
     )
 
-    svid = _WORKLOAD_API_CLIENT.fetch_x509_svid()
+    svid = WORKLOAD_API_CLIENT.fetch_x509_svid()
 
     assert svid.spiffe_id() == SpiffeId.parse('spiffe://example.org/service')
     assert len(svid.cert_chain()) == 2
@@ -52,12 +51,12 @@ def test_fetch_x509_svid_success(mocker):
 
 
 def test_fetch_x509_svid_empty_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([workload_pb2.X509SVIDResponse(svids=[])])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svid()
+        WORKLOAD_API_CLIENT.fetch_x509_svid()
 
     assert (
         str(exception.value)
@@ -66,12 +65,12 @@ def test_fetch_x509_svid_empty_response(mocker):
 
 
 def test_fetch_x509_svid_invalid_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svid()
+        WORKLOAD_API_CLIENT.fetch_x509_svid()
 
     assert (
         str(exception.value)
@@ -80,12 +79,12 @@ def test_fetch_x509_svid_invalid_response(mocker):
 
 
 def test_fetch_x509_svid_raise_exception(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svid()
+        WORKLOAD_API_CLIENT.fetch_x509_svid()
 
     assert (
         str(exception.value)
@@ -94,7 +93,7 @@ def test_fetch_x509_svid_raise_exception(mocker):
 
 
 def test_fetch_x509_svid_corrupted_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -116,7 +115,7 @@ def test_fetch_x509_svid_corrupted_response(mocker):
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svid()
+        WORKLOAD_API_CLIENT.fetch_x509_svid()
 
     assert (
         str(exception.value)
@@ -125,7 +124,7 @@ def test_fetch_x509_svid_corrupted_response(mocker):
 
 
 def test_fetch_x509_svids_success(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -146,7 +145,7 @@ def test_fetch_x509_svids_success(mocker):
         )
     )
 
-    svids = _WORKLOAD_API_CLIENT.fetch_x509_svids()
+    svids = WORKLOAD_API_CLIENT.fetch_x509_svids()
 
     assert len(svids) == 2
 
@@ -164,12 +163,12 @@ def test_fetch_x509_svids_success(mocker):
 
 
 def test_fetch_x509_svids_empty_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([workload_pb2.X509SVIDResponse(svids=[])])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svids()
+        WORKLOAD_API_CLIENT.fetch_x509_svids()
 
     assert (
         str(exception.value)
@@ -178,12 +177,12 @@ def test_fetch_x509_svids_empty_response(mocker):
 
 
 def test_fetch_x509_svids_invalid_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svids()
+        WORKLOAD_API_CLIENT.fetch_x509_svids()
 
     assert (
         str(exception.value)
@@ -192,12 +191,12 @@ def test_fetch_x509_svids_invalid_response(mocker):
 
 
 def test_fetch_x509_svids_raise_exception(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svids()
+        WORKLOAD_API_CLIENT.fetch_x509_svids()
 
     assert (
         str(exception.value)
@@ -206,7 +205,7 @@ def test_fetch_x509_svids_raise_exception(mocker):
 
 
 def test_fetch_x509_svids_corrupted_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -228,7 +227,7 @@ def test_fetch_x509_svids_corrupted_response(mocker):
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_svids()
+        WORKLOAD_API_CLIENT.fetch_x509_svids()
 
     assert (
         str(exception.value)
@@ -240,7 +239,7 @@ def test_fetch_x509_context_success(mocker):
     federated_bundles = dict()
     federated_bundles['domain.test'] = _FEDERATED_BUNDLE
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -264,7 +263,7 @@ def test_fetch_x509_context_success(mocker):
         )
     )
 
-    x509_context = _WORKLOAD_API_CLIENT.fetch_x509_context()
+    x509_context = WORKLOAD_API_CLIENT.fetch_x509_context()
 
     svids = x509_context.x509_svids()
     bundle_set = x509_context.x509_bundle_set()
@@ -295,12 +294,12 @@ def test_fetch_x509_context_success(mocker):
 
 
 def test_fetch_x509_context_empty_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([workload_pb2.X509SVIDResponse(svids=[])])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert (
         str(exception.value)
@@ -309,12 +308,12 @@ def test_fetch_x509_context_empty_response(mocker):
 
 
 def test_fetch_x509_context_invalid_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter([])
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert (
         str(exception.value)
@@ -323,12 +322,12 @@ def test_fetch_x509_context_invalid_response(mocker):
 
 
 def test_fetch_x509_context_raise_exception(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert (
         str(exception.value)
@@ -340,7 +339,7 @@ def test_fetch_x509_context_corrupted_svid(mocker):
     federated_bundles = dict()
     federated_bundles['domain.test'] = _FEDERATED_BUNDLE
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -365,7 +364,7 @@ def test_fetch_x509_context_corrupted_svid(mocker):
     )
 
     with (pytest.raises(FetchX509SvidError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert 'Error fetching X.509 SVID: Error parsing private key' in str(
         exception.value
@@ -376,7 +375,7 @@ def test_fetch_x509_context_corrupted_bundle(mocker):
     federated_bundles = dict()
     federated_bundles['domain.test'] = _FEDERATED_BUNDLE
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -401,7 +400,7 @@ def test_fetch_x509_context_corrupted_bundle(mocker):
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert (
         str(exception.value)
@@ -413,7 +412,7 @@ def test_fetch_x509_context_corrupted_federated_bundle(mocker):
     federated_bundles = dict()
     federated_bundles['domain.test'] = _CORRUPTED
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509SVIDResponse(
@@ -438,7 +437,7 @@ def test_fetch_x509_context_corrupted_federated_bundle(mocker):
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_context()
+        WORKLOAD_API_CLIENT.fetch_x509_context()
 
     assert (
         str(exception.value)
@@ -451,7 +450,7 @@ def test_fetch_x509_bundles_success(mocker):
     bundles['example.org'] = _BUNDLE
     bundles['domain.test'] = _FEDERATED_BUNDLE
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509BundlesResponse(
@@ -461,7 +460,7 @@ def test_fetch_x509_bundles_success(mocker):
         )
     )
 
-    bundle_set = _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+    bundle_set = WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     bundle = bundle_set.get_x509_bundle_for_trust_domain(TrustDomain('example.org'))
     assert bundle
@@ -475,12 +474,12 @@ def test_fetch_x509_bundles_success(mocker):
 
 
 def test_fetch_x509_bundles_empty_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         return_value=iter([workload_pb2.X509BundlesResponse(bundles=[])])
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     assert (
         str(exception.value)
@@ -489,12 +488,12 @@ def test_fetch_x509_bundles_empty_response(mocker):
 
 
 def test_fetch_x509_bundles_invalid_response(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         return_value=iter([])
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     assert (
         str(exception.value)
@@ -503,12 +502,12 @@ def test_fetch_x509_bundles_invalid_response(mocker):
 
 
 def test_fetch_x509_bundles_raise_exception(mocker):
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         side_effect=Exception('mocked error')
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     assert (
         str(exception.value)
@@ -521,7 +520,7 @@ def test_fetch_x509_bundles_corrupted_bundle(mocker):
     bundles['example.org'] = _CORRUPTED
     bundles['domain.test'] = _FEDERATED_BUNDLE
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509BundlesResponse(
@@ -532,7 +531,7 @@ def test_fetch_x509_bundles_corrupted_bundle(mocker):
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     assert (
         str(exception.value)
@@ -545,7 +544,7 @@ def test_fetch_x509_bundles_corrupted_federated_bundle(mocker):
     bundles['example.org'] = _BUNDLE
     bundles['domain.test'] = _CORRUPTED
 
-    _WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         return_value=iter(
             [
                 workload_pb2.X509BundlesResponse(
@@ -556,7 +555,7 @@ def test_fetch_x509_bundles_corrupted_federated_bundle(mocker):
     )
 
     with (pytest.raises(FetchX509BundleError)) as exception:
-        _WORKLOAD_API_CLIENT.fetch_x509_bundles()
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
     assert (
         str(exception.value)


### PR DESCRIPTION
This PR also updates the code to use a set instead of a list as parameters when calling `JwtSvid()`, `JwtSvid.parse_insecure()` and `JwtSvid.pase_and_validate()`. This where required based on a previous update.
