### PR TITLE
All exception messages end up with a dot automatically.

### DIFF
--- a/src/pyspiffe/bundle/jwt_bundle/exceptions.py
+++ b/src/pyspiffe/bundle/jwt_bundle/exceptions.py
@@ -14,7 +14,7 @@ class JwtBundleError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message

--- a/src/pyspiffe/bundle/jwt_bundle/jwt_bundle.py
+++ b/src/pyspiffe/bundle/jwt_bundle/jwt_bundle.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa, dsa, ed25519, ed4
 
 from pyspiffe.spiffe_id.trust_domain import TrustDomain, EMPTY_DOMAIN_ERROR
 from pyspiffe.bundle.jwt_bundle.exceptions import JwtBundleError
+from pyspiffe.exceptions import ArgumentError
 
 _PUBLIC_KEY_TYPES = Union[
     dsa.DSAPublicKey,
@@ -60,10 +61,10 @@ class JwtBundle(object):
             None if the key_id is not found.
 
         Raises:
-            ValueError: When key_id is not valid (empty or None).
+            ArgumentError: When key_id is not valid (empty or None).
         """
         if not key_id:
-            raise ValueError('key_id cannot be empty.')
+            raise ArgumentError('key_id cannot be empty')
 
         with self.lock:
             return self._jwt_authorities.get(key_id)

--- a/src/pyspiffe/bundle/x509_bundle/exceptions.py
+++ b/src/pyspiffe/bundle/x509_bundle/exceptions.py
@@ -15,7 +15,7 @@ class X509BundleError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message
@@ -24,7 +24,7 @@ class X509BundleError(PySpiffeError):
 class ParseX509BundleError(X509BundleError):
     """Error raised when an X.509 bundle could not be parsed from bytes."""
 
-    _MESSAGE = 'Error parsing X.509 bundle: {}.'
+    _MESSAGE = 'Error parsing X.509 bundle: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of ParseX509BundleError.
@@ -38,7 +38,7 @@ class ParseX509BundleError(X509BundleError):
 class LoadX509BundleError(X509BundleError):
     """Error raised when an X.509 bundle could not be loaded from file."""
 
-    _MESSAGE = 'Error loading X.509 bundle: {}.'
+    _MESSAGE = 'Error loading X.509 bundle: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of LoadX509BundleError.
@@ -52,7 +52,7 @@ class LoadX509BundleError(X509BundleError):
 class SaveX509BundleError(X509BundleError):
     """Error raised when an X.509 bundle could not be save to file."""
 
-    _MESSAGE = 'Error saving X.509 bundle: {}.'
+    _MESSAGE = 'Error saving X.509 bundle: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of SaveX509BundleError.

--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -7,7 +7,7 @@ from typing import Set
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import Certificate
-
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.bundle.x509_bundle.exceptions import (
     X509BundleError,
     SaveX509BundleError,
@@ -158,8 +158,8 @@ class X509Bundle(object):
         if encoding == serialization.Encoding.DER:
             return cls.parse_raw(trust_domain, bundle_bytes)
 
-        raise ValueError(
-            'Encoding not supported: {}. Expected \'PEM\' or \'DER\'.'.format(encoding)
+        raise ArgumentError(
+            'Encoding not supported: {}. Expected \'PEM\' or \'DER\''.format(encoding)
         )
 
     @classmethod
@@ -177,15 +177,15 @@ class X509Bundle(object):
             encoding: Bundle encoding format, either serialization.Encoding.PEM or serialization.Encoding.DER
 
         Raises:
-            ValueError: In case the encoding is not either PEM or DER (from serialization.Encoding)
+            ArgumentError: In case the encoding is not either PEM or DER (from serialization.Encoding)
             X509BundleError: In case the authorities in the bundle cannot be converted to bytes.
             SaveX509BundleError: In the case the file path in bundle_path cannot be open to write, or there is an error
                                 writing the authorities bytes to the file.
         """
 
         if encoding not in [encoding.PEM, encoding.DER]:
-            raise ValueError(
-                'Encoding not supported: {}. Expected \'PEM\' or \'DER\'.'.format(
+            raise ArgumentError(
+                'Encoding not supported: {}. Expected \'PEM\' or \'DER\''.format(
                     encoding
                 )
             )

--- a/src/pyspiffe/exceptions.py
+++ b/src/pyspiffe/exceptions.py
@@ -6,4 +6,30 @@ This module defines py-spiffe top level exceptions.
 class PySpiffeError(Exception):
     """Top level exception for py-spiffe library."""
 
-    pass
+    def __init__(self, message: str) -> None:
+        """Creates an instance of WorkloadApiError.
+
+        Args:
+            message: Message describing the error.
+        """
+
+        self.message = message if message[-1] == '.' else message + '.'
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ArgumentError(PySpiffeError):
+    """Validation error for py-spiffe library."""
+
+    def __init__(self, message: str) -> None:
+        """Creates an instance of ArgumentError.
+
+        Args:
+            message: Message describing the error.
+        """
+
+        super().__init__(message)
+
+    def __str__(self) -> str:
+        return super().__str__()

--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -7,8 +7,9 @@ from typing import Any, cast
 
 
 from pyspiffe.spiffe_id import SPIFFE_SCHEME
+from pyspiffe.exceptions import ArgumentError
 
-EMPTY_DOMAIN_ERROR = 'Trust domain cannot be empty.'
+EMPTY_DOMAIN_ERROR = 'Trust domain cannot be empty'
 """str: Default error message for empty Trust Domains."""
 
 SCHEME_SUFFIX = '://'
@@ -28,7 +29,7 @@ class TrustDomain(object):
             name: The name of the Trust Domain.
 
         Raises:
-            ValueError: If the name of the trust domain is empty, has a port, or contains an invalid scheme.
+            ArgumentError: If the name of the trust domain is empty, has a port, or contains an invalid scheme.
 
         Examples:
             >>> trust_domain = TrustDomain('Domain.Test')
@@ -60,11 +61,11 @@ class TrustDomain(object):
 
     def __set_name(self, name: str) -> None:
         if not name:
-            raise ValueError(EMPTY_DOMAIN_ERROR)
+            raise ArgumentError(EMPTY_DOMAIN_ERROR)
 
         if len(name) > TRUST_DOMAIN_MAXIMUM_LENGTH:
-            raise ValueError(
-                'Trust domain cannot be longer than {} bytes.'.format(
+            raise ArgumentError(
+                'Trust domain cannot be longer than {} bytes'.format(
                     TRUST_DOMAIN_MAXIMUM_LENGTH
                 )
             )
@@ -84,10 +85,10 @@ class TrustDomain(object):
     @staticmethod
     def validate_uri(uri: ParseResult) -> None:
         if uri.scheme != SPIFFE_SCHEME:
-            raise ValueError(
-                'Trust domain: invalid scheme: expected {}.'.format(SPIFFE_SCHEME)
+            raise ArgumentError(
+                'Trust domain: invalid scheme: expected {}'.format(SPIFFE_SCHEME)
             )
         if not uri.hostname:
-            raise ValueError(EMPTY_DOMAIN_ERROR)
+            raise ArgumentError(EMPTY_DOMAIN_ERROR)
         if uri.port:
-            raise ValueError('Trust domain: port is not allowed.')
+            raise ArgumentError('Trust domain: port is not allowed')

--- a/src/pyspiffe/svid/__init__.py
+++ b/src/pyspiffe/svid/__init__.py
@@ -2,5 +2,5 @@
 This module manages X509 and JWT SVID objects.
 """
 
-INVALID_INPUT_ERROR = 'Invalid input: {}.'
+INVALID_INPUT_ERROR = 'Invalid input: {}'
 """str: generic error message."""

--- a/src/pyspiffe/svid/exceptions.py
+++ b/src/pyspiffe/svid/exceptions.py
@@ -18,7 +18,7 @@ class JwtSvidError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message
@@ -39,7 +39,7 @@ class InvalidTokenError(JwtSvidError):
 class InvalidClaimError(JwtSvidError):
     """Error raised when an invalid value is found in the JWT token claims."""
 
-    _MESSAGE = 'Invalid claim value: {}.'
+    _MESSAGE = 'Invalid claim value: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of InvalidClaimError adding the provided additional_information to the error message.
@@ -53,7 +53,7 @@ class InvalidClaimError(JwtSvidError):
 class MissingClaimError(JwtSvidError):
     """Error raised when missing required claims in the JWT token."""
 
-    _MESSAGE = 'Missing required claim: {}.'
+    _MESSAGE = 'Missing required claim: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of MissingClaimError adding the provided additional_information to the error message.
@@ -112,7 +112,7 @@ class X509SvidError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message
@@ -121,7 +121,7 @@ class X509SvidError(PySpiffeError):
 class InvalidLeafCertificateError(X509SvidError):
     """Error raised when an invalid leaf certificate is found in the X.509 chain."""
 
-    _MESSAGE = 'Invalid leaf certificate: {}.'
+    _MESSAGE = 'Invalid leaf certificate: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of InvalidLeafCertificateError
@@ -135,7 +135,7 @@ class InvalidLeafCertificateError(X509SvidError):
 class InvalidIntermediateCertificateError(X509SvidError):
     """Error raised when an invalid intermediate certificate is found in the X.509 chain."""
 
-    _MESSAGE = 'Invalid intermediate certificate: {}.'
+    _MESSAGE = 'Invalid intermediate certificate: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of InvalidIntermediateCertificateError
@@ -149,7 +149,7 @@ class InvalidIntermediateCertificateError(X509SvidError):
 class ParseCertificateError(X509SvidError):
     """Error raised when an certificate could not be parsed from bytes."""
 
-    _MESSAGE = 'Error parsing certificate: {}.'
+    _MESSAGE = 'Error parsing certificate: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of ParseCertificateError
@@ -163,7 +163,7 @@ class ParseCertificateError(X509SvidError):
 class ParsePrivateKeyError(X509SvidError):
     """Error raised when the private key could not be parsed from bytes."""
 
-    _MESSAGE = 'Error parsing private key: {}.'
+    _MESSAGE = 'Error parsing private key: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of ParsePrivateKeyError
@@ -177,7 +177,7 @@ class ParsePrivateKeyError(X509SvidError):
 class StoreCertificateError(X509SvidError):
     """Error raised when an certificate could not be saved to disk."""
 
-    _MESSAGE = 'Error saving certificate to file: {}.'
+    _MESSAGE = 'Error saving certificate to file: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of StoreCertificateError
@@ -191,7 +191,7 @@ class StoreCertificateError(X509SvidError):
 class StorePrivateKeyError(X509SvidError):
     """Error raised when the private key could not be saved to disk."""
 
-    _MESSAGE = 'Error saving private key to file: {}.'
+    _MESSAGE = 'Error saving private key to file: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of StorePrivateKeyError
@@ -205,7 +205,7 @@ class StorePrivateKeyError(X509SvidError):
 class LoadCertificateError(X509SvidError):
     """Error raised when an certificate could not be loaded from disk."""
 
-    _MESSAGE = 'Error loading certificate from file: {}.'
+    _MESSAGE = 'Error loading certificate from file: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of LoadCertificateError
@@ -219,7 +219,7 @@ class LoadCertificateError(X509SvidError):
 class LoadPrivateKeyError(X509SvidError):
     """Error raised when the private key could not be loaded from disk."""
 
-    _MESSAGE = 'Error loading private key from file: {}.'
+    _MESSAGE = 'Error loading private key from file: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of LoadPrivateKeyError

--- a/src/pyspiffe/svid/jwt_svid.py
+++ b/src/pyspiffe/svid/jwt_svid.py
@@ -6,6 +6,7 @@ import jwt
 from jwt import PyJWTError
 from typing import Dict, List
 from pyspiffe.svid import INVALID_INPUT_ERROR
+from pyspiffe.exceptions import ArgumentError
 from cryptography.hazmat.primitives import serialization
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
 from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
@@ -57,7 +58,7 @@ class JwtSvid(object):
             from 'exp' claim.
 
         Raises:
-            ValueError: When the token is blank or cannot be parsed, or in case header is not specified or in case expected_audience is empty or
+            ArgumentError: When the token is blank or cannot be parsed, or in case header is not specified or in case expected_audience is empty or
                 if the SPIFFE ID in the 'sub' claim doesn't comply with the SPIFFE standard.
             InvalidAlgorithmError: In case specified 'alg' is not supported as specified by the SPIFFE standard.
             InvalidTypeError: If 'typ' is present in header but is not set to 'JWT' or 'JOSE'.
@@ -66,7 +67,7 @@ class JwtSvid(object):
             InvalidTokenError: If token is malformed and fails to decode.
         """
         if not token:
-            raise ValueError(INVALID_INPUT_ERROR.format('token cannot be empty'))
+            raise ArgumentError(INVALID_INPUT_ERROR.format('token cannot be empty'))
         try:
             header_params = jwt.get_unverified_header(token)
             validator = JwtSvidValidator()
@@ -100,18 +101,19 @@ class JwtSvid(object):
                             when the algorithm is not supported, when the header 'kid' is missing,
                             when the signature cannot be verified, or
                             when the 'aud' claim has an audience that is not in the audience list provided as parameter.
-            ValueError:     When the token is blank or cannot be parsed.
+            ArgumentError:     When the token is blank or cannot be parsed.
             BundleNotFoundError:    If the bundle for the trust domain of the spiffe id from the 'sub'
                                     cannot be found the jwt_bundle_source.
             AuthorityNotFoundError: If the authority cannot be found in the bundle using the value from the 'kid' header.
             InvalidTokenError: In case token is malformed and fails to decode.
         """
         if not token:
-            raise ValueError(INVALID_INPUT_ERROR.format('token cannot be empty'))
+            raise ArgumentError(INVALID_INPUT_ERROR.format('token cannot be empty'))
 
         if not jwt_bundle:
-            raise ValueError(INVALID_INPUT_ERROR.format('jwt_bundle cannot be empty'))
-
+            raise ArgumentError(
+                INVALID_INPUT_ERROR.format('jwt_bundle cannot be empty')
+            )
         try:
             header_params = jwt.get_unverified_header(token)
             validator = JwtSvidValidator()
@@ -143,5 +145,5 @@ class JwtSvid(object):
             return JwtSvid(spiffe_id, claims['aud'], claims['exp'], claims, token)
         except PyJWTError as err:
             raise InvalidTokenError(str(err))
-        except ValueError as value_err:
+        except ArgumentError as value_err:
             raise InvalidTokenError(str(value_err))

--- a/src/pyspiffe/svid/jwt_svid_validator.py
+++ b/src/pyspiffe/svid/jwt_svid_validator.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Any
 from calendar import timegm
 
 from pyspiffe.svid import INVALID_INPUT_ERROR
-
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.svid.exceptions import (
     TokenExpiredError,
     InvalidClaimError,
@@ -56,16 +56,18 @@ class JwtSvidValidator(object):
             None.
 
         Raises:
-            ValueError: In case header is not specified.
+            ArgumentError: In case header is not specified.
             InvalidAlgorithmError: In case specified 'alg' is not supported as specified by the SPIFFE standard.
             InvalidTypeError: In case 'typ' is present in header but is not set to 'JWT' or 'JOSE'.
         """
         if not parameters:
-            raise ValueError(INVALID_INPUT_ERROR.format('header cannot be empty'))
+            raise ArgumentError(INVALID_INPUT_ERROR.format('header cannot be empty'))
 
         alg = parameters.get('alg')
         if not alg:
-            raise ValueError(INVALID_INPUT_ERROR.format('header alg cannot be empty'))
+            raise ArgumentError(
+                INVALID_INPUT_ERROR.format('header alg cannot be empty')
+            )
 
         if alg not in self._SUPPORTED_ALGORITHMS:
             raise InvalidAlgorithmError(alg)
@@ -90,7 +92,7 @@ class JwtSvidValidator(object):
             MissingClaimError: In case a required claim is not present.
             InvalidClaimError: In case a claim contains an invalid value or expected_audience is not a subset of audience_claim.
             TokenExpiredError: In case token is expired.
-            ValueError: In case expected_audience is empty.
+            ArgumentError: In case expected_audience is empty.
         """
         for claim in self._REQUIRED_CLAIMS:
             if not payload.get(claim):
@@ -126,10 +128,10 @@ class JwtSvidValidator(object):
 
         Raises:
             InvalidClaimError: In expected_audience is not a subset of audience_claim or it is empty.
-            ValueError: In case expected_audience is empty.
+            ArgumentError: In case expected_audience is empty.
         """
         if not expected_audience:
-            raise ValueError(
+            raise ArgumentError(
                 INVALID_INPUT_ERROR.format('expected_audience cannot be empty')
             )
 

--- a/src/pyspiffe/utils/exceptions.py
+++ b/src/pyspiffe/utils/exceptions.py
@@ -11,16 +11,7 @@ class X509CertificateError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message
-
-
-def normalized_exception_message(e: Exception) -> str:
-    """Removes the last point from the exception message."""
-
-    msg = str(e)
-    if msg[-1] != '.':
-        return msg
-    return msg[:-1]

--- a/src/pyspiffe/workloadapi/exceptions.py
+++ b/src/pyspiffe/workloadapi/exceptions.py
@@ -15,7 +15,7 @@ class WorkloadApiError(PySpiffeError):
             message: Message describing the error.
         """
 
-        self.message = message
+        super().__init__(message)
 
     def __str__(self) -> str:
         return self.message
@@ -24,7 +24,7 @@ class WorkloadApiError(PySpiffeError):
 class FetchX509SvidError(WorkloadApiError):
     """Error raised when there is an error fetching X.509 SVIDs."""
 
-    _MESSAGE = 'Error fetching X.509 SVID: {}.'
+    _MESSAGE = 'Error fetching X.509 SVID: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of FetchX509SvidError.
@@ -38,7 +38,7 @@ class FetchX509SvidError(WorkloadApiError):
 class FetchX509BundleError(WorkloadApiError):
     """Error raised when there is an error fetching X.509 Bundles."""
 
-    _MESSAGE = 'Error fetching X.509 Bundles: {}.'
+    _MESSAGE = 'Error fetching X.509 Bundles: {}'
 
     def __init__(self, additional_information: str) -> None:
         """Creates an instance of FetchX509BundleError.
@@ -52,7 +52,7 @@ class FetchX509BundleError(WorkloadApiError):
 class FetchJwtSvidError(WorkloadApiError):
     """Error raised when there is an error fetching JWT SVIDs."""
 
-    _MESSAGE = 'Error fetching JWT SVID: {}.'
+    _MESSAGE = 'Error fetching JWT SVID: {}'
 
     def __init__(self, additional_information: str = 'none') -> None:
         """Creates an instance of FetchJwtSvidError.

--- a/test/bundle/jwt_bundle/test_jwt_bundle.py
+++ b/test/bundle/jwt_bundle/test_jwt_bundle.py
@@ -5,6 +5,7 @@ from cryptography.hazmat.backends import default_backend
 from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
 from pyspiffe.bundle.jwt_bundle.exceptions import JwtBundleError
+from pyspiffe.exceptions import ArgumentError
 
 # Default trust domain to run test cases.
 trust_domain = TrustDomain("spiffe://any.domain")
@@ -64,7 +65,7 @@ def test_get_jwt_authority_invalid_key_id_not_found():
 def test_get_jwt_authority_invalid_input():
     jwt_bundle = JwtBundle(trust_domain, authorities)
 
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         jwt_bundle.get_jwt_authority('')
 
     assert str(exception.value) == 'key_id cannot be empty.'

--- a/test/bundle/x509bundle/test_x509_bundle.py
+++ b/test/bundle/x509bundle/test_x509_bundle.py
@@ -13,6 +13,7 @@ from pyspiffe.bundle.x509_bundle.exceptions import (
 )
 from pyspiffe.bundle.x509_bundle.x509_bundle import X509Bundle
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.exceptions import ArgumentError
 
 _TEST_CERTS_PATH = 'test/bundle/x509bundle/certs/{}'
 trust_domain = TrustDomain('domain.test')
@@ -160,7 +161,7 @@ def test_load_bundle_empty_trust_domain():
 def test_load_bundle_invalid_encoding():
     bundle_path = _TEST_CERTS_PATH.format('certs.pem')
 
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         X509Bundle.load(trust_domain, bundle_path, serialization.Encoding.Raw)
 
     assert (
@@ -226,7 +227,7 @@ def test_save_non_supported_encoding(tmpdir):
 
     bundle_path = tmpdir.join('bundle.pem')
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ArgumentError) as err:
         X509Bundle.save(x509_bundle, bundle_path, serialization.Encoding.Raw)
 
     assert (

--- a/test/spiffe_id/test_spiffe_id.py
+++ b/test/spiffe_id/test_spiffe_id.py
@@ -2,6 +2,7 @@ import pytest
 
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.exceptions import ArgumentError
 
 
 @pytest.mark.parametrize(
@@ -111,7 +112,7 @@ def test_parse_spiffe_id_valid_uri(spiffe_id_str, expected_trust_domain, expecte
     ],
 )
 def test_parse_spiffe_id_from_invalid_uri_string(spiffe_id_str, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         SpiffeId.parse(spiffe_id_str)
 
     assert str(exception.value) == expected
@@ -145,14 +146,14 @@ def test_not_equal_when_different_objects():
 
 
 def test_trust_domain_none():
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         SpiffeId.of(None, 'path')
 
     assert str(exception.value) == 'SPIFFE ID: trust domain cannot be empty.'
 
 
 def test_of_empty_trust_domain():
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         SpiffeId.of('', 'path')
 
     assert (
@@ -164,7 +165,7 @@ def test_of_empty_trust_domain():
 def test_exceeds_maximum_length():
     path = 'a' * 2028
 
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         SpiffeId.parse('spiffe://example.org/{}'.format(path))
 
     assert str(exception.value) == 'SPIFFE ID: maximum length is 2048 bytes.'

--- a/test/spiffe_id/test_trust_domain.py
+++ b/test/spiffe_id/test_trust_domain.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pyspiffe.spiffe_id.trust_domain import TrustDomain
+from pyspiffe.exceptions import ArgumentError
 
 
 @pytest.mark.parametrize(
@@ -32,7 +33,7 @@ def test_valid_trust_domain(test_input, expected):
     ],
 )
 def test_invalid_trust_domain(test_input, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         TrustDomain(test_input)
 
     assert str(exception.value) == expected
@@ -69,7 +70,7 @@ def test_not_equal_when_different_objects():
 def test_exceeds_maximum_length():
     name = "a" * 256
 
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         TrustDomain("{}".format(name))
 
     assert str(exception.value) == 'Trust domain cannot be longer than 255 bytes.'

--- a/test/svid/jwtsvid/test_jwt_svid.py
+++ b/test/svid/jwtsvid/test_jwt_svid.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.backends import default_backend
 from pyspiffe.svid import INVALID_INPUT_ERROR
 from pyspiffe.svid.jwt_svid import JwtSvid
 from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.svid.exceptions import (
     TokenExpiredError,
     JwtSvidError,
@@ -35,14 +36,14 @@ JWT_BUNDLE = JwtBundle(DEFAULT_TRUST_DOMAIN, {'kid1': DEFAULT_KEY.public_key()})
 @pytest.mark.parametrize(
     'test_input_token,test_input_audience, expected',
     [
-        ('', [], INVALID_INPUT_ERROR.format('token cannot be empty')),
-        ('', None, INVALID_INPUT_ERROR.format('token cannot be empty')),
-        (None, [], INVALID_INPUT_ERROR.format('token cannot be empty')),
-        (None, None, INVALID_INPUT_ERROR.format('token cannot be empty')),
+        ('', [], INVALID_INPUT_ERROR.format('token cannot be empty.')),
+        ('', None, INVALID_INPUT_ERROR.format('token cannot be empty.')),
+        (None, [], INVALID_INPUT_ERROR.format('token cannot be empty.')),
+        (None, None, INVALID_INPUT_ERROR.format('token cannot be empty.')),
     ],
 )
 def test_parse_insecure_invalid_input(test_input_token, test_input_audience, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         JwtSvid.parse_insecure(test_input_token, test_input_audience)
 
     assert str(exception.value) == expected
@@ -197,20 +198,20 @@ def test_parse_insecure_valid(test_input_token, test_input_audience, expected):
             '',
             None,
             ['spire'],
-            INVALID_INPUT_ERROR.format('token cannot be empty'),
+            INVALID_INPUT_ERROR.format('token cannot be empty.'),
         ),
         (
             'eyJhbGciOiJFUzI1NiIsImtpZCI6Imd1eTdsOWZSQzhkQW1IUmFtaFpQbktRa3lId2FHQzR0IiwidHlwIjoiSldUIn0.eyJhdWQiOlsib3RoZXItc2VydmljZSJdLCJleHAiOjE2MTIyOTAxODMsImlhdCI6MTYxMjI4OTg4Mywic3ViIjoic3hthrtmZlOi8vZXhhbXBsZS5vcmcvc2VydmljZSJ9.W7CLQvYVBQ8Zg3ELcuB1K9hE4I9wyCMB_8PJTZXbjnlMBcgd0VDbSm5OjoqcGQF975eaVl_AdkryJ_lzxsEQ4A',
             None,
             ['spire'],
-            INVALID_INPUT_ERROR.format('jwt_bundle cannot be empty'),
+            INVALID_INPUT_ERROR.format('jwt_bundle cannot be empty.'),
         ),
     ],
 )
 def test_parse_and_validate_invalid_parameters(
     test_input_token, test_input_jwt_bundle, test_input_audience, expected
 ):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         JwtSvid.parse_and_validate(
             test_input_token, test_input_jwt_bundle, test_input_audience
         )
@@ -252,7 +253,7 @@ def test_parse_and_validate_invalid_kid_mismatch():
 
     with pytest.raises(InvalidTokenError) as exception:
         JwtSvid.parse_and_validate(token, jwt_bundle, ['spire'])
-    assert str(exception.value) == 'Signature verification failed'
+    assert str(exception.value) == 'Signature verification failed.'
 
 
 def test_parse_and_validate_valid_token_RSA():

--- a/test/svid/jwtsvid/test_jwt_svid_validator.py
+++ b/test/svid/jwtsvid/test_jwt_svid_validator.py
@@ -7,6 +7,7 @@ from pyspiffe.svid.jwt_svid_validator import (
     INVALID_INPUT_ERROR,
     AUDIENCE_NOT_MATCH_ERROR,
 )
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.svid.exceptions import (
     TokenExpiredError,
     InvalidClaimError,
@@ -35,7 +36,7 @@ from pyspiffe.svid.exceptions import (
                 'sub': 'spiffeid://somewhere.over.the',
             },
             None,
-            INVALID_INPUT_ERROR.format('expected_audience cannot be empty'),
+            INVALID_INPUT_ERROR.format('expected_audience cannot be empty.'),
         ),
         (
             {
@@ -48,12 +49,12 @@ from pyspiffe.svid.exceptions import (
                 'sub': 'spiffeid://somewhere.over.the',
             },
             set(),
-            INVALID_INPUT_ERROR.format('expected_audience cannot be empty'),
+            INVALID_INPUT_ERROR.format('expected_audience cannot be empty.'),
         ),
     ],
 )
-def test_validate_claims_invalid_input(test_input_claim, test_input_audience, expected):
-    with pytest.raises(ValueError) as exception:
+def test_invalid_input_validate_claims(test_input_claim, test_input_audience, expected):
+    with pytest.raises(ArgumentError) as exception:
         JwtSvidValidator().validate_claims(test_input_claim, test_input_audience)
 
     assert str(exception.value) == expected
@@ -277,21 +278,21 @@ def test_validate_claims_valid_input(test_input_claim, test_input_audience):
     [
         (
             None,
-            INVALID_INPUT_ERROR.format('header cannot be empty'),
+            INVALID_INPUT_ERROR.format('header cannot be empty.'),
         ),
         (
             '',
-            INVALID_INPUT_ERROR.format('header cannot be empty'),
+            INVALID_INPUT_ERROR.format('header cannot be empty.'),
         ),
         (
             {'ttt': 'eee'},
-            INVALID_INPUT_ERROR.format('header alg cannot be empty'),
+            INVALID_INPUT_ERROR.format('header alg cannot be empty.'),
         ),
-        ({'alg': ''}, INVALID_INPUT_ERROR.format('header alg cannot be empty')),
+        ({'alg': ''}, INVALID_INPUT_ERROR.format('header alg cannot be empty.')),
     ],
 )
 def test_validate_header_invalid_input(test_input_header, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         JwtSvidValidator().validate_header(test_input_header)
 
     assert str(exception.value) == expected

--- a/test/svid/x509svid/test_x509_svid.py
+++ b/test/svid/x509svid/test_x509_svid.py
@@ -3,6 +3,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import Certificate
 
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.svid.exceptions import (
     InvalidLeafCertificateError,
     InvalidIntermediateCertificateError,
@@ -37,21 +38,21 @@ def test_create_x509_svid(mocker):
 
 
 def test_create_x509_svid_no_spiffe_id(mocker):
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ArgumentError) as exc_info:
         X509Svid(spiffe_id=None, cert_chain=[mocker.Mock()], private_key=mocker.Mock())
 
     assert str(exc_info.value) == 'spiffe_id cannot be None.'
 
 
 def test_create_x509_svid_no_cert_chain(mocker):
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ArgumentError) as exc_info:
         X509Svid(spiffe_id=mocker.Mock(), cert_chain=[], private_key=mocker.Mock())
 
     assert str(exc_info.value) == 'cert_chain cannot be empty.'
 
 
 def test_create_x509_svid_no_private_key(mocker):
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ArgumentError) as exc_info:
         X509Svid(spiffe_id=mocker.Mock(), cert_chain=[mocker.Mock()], private_key=None)
 
     assert str(exc_info.value) == 'private_key cannot be None.'
@@ -422,7 +423,7 @@ def test_save_non_supported_encoding():
     # create the X509Svid to be saved
     mock_x509_svid = X509Svid.parse(chain_bytes, key_bytes)
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ArgumentError) as err:
         X509Svid.save(
             mock_x509_svid, 'chain_file', 'key_file', serialization.Encoding.Raw
         )
@@ -483,7 +484,7 @@ def test_save_error_extracting_private_key(mocker):
 def test_load_non_supported_encoding():
     chain_path = _TEST_CERTS_PATH.format('2-chain.pem')
     key_path = _TEST_CERTS_PATH.format('2-key.pem')
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ArgumentError) as err:
         X509Svid.load(chain_path, key_path, serialization.Encoding.OpenSSH)
 
     assert (

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,6 +1,7 @@
+import os
 import pytest
 from pyspiffe.config import ConfigSetter
-import os
+from pyspiffe.exceptions import ArgumentError
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +13,7 @@ def restore_env_vars():
 
 
 def test_socket_must_be_set():
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         ConfigSetter()
 
     assert str(exception.value) == 'SPIFFE endpoint socket: socket must be set.'
@@ -129,7 +130,7 @@ def test_path_scheme_is_valid_tcp():
     ],
 )
 def test_invalid_endpoint_socket(test_input, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         ConfigSetter(spiffe_endpoint_socket=test_input)
 
     assert str(exception.value) == expected

--- a/test/utils/test_certificate_utils.py
+++ b/test/utils/test_certificate_utils.py
@@ -45,7 +45,7 @@ def test_parse_der_corrupted_certificate():
     with pytest.raises(X509CertificateError) as exception:
         parse_der_certificates(certs_bytes)
 
-    assert str(exception.value) == 'Unable to parse DER X.509 certificate'
+    assert str(exception.value) == 'Unable to parse DER X.509 certificate.'
 
 
 def test_parse_pem_corrupted_certificate():
@@ -54,7 +54,7 @@ def test_parse_pem_corrupted_certificate():
     with pytest.raises(X509CertificateError) as exception:
         parse_pem_certificates(certs_bytes)
 
-    assert str(exception.value) == 'Unable to parse PEM X.509 certificate'
+    assert str(exception.value) == 'Unable to parse PEM X.509 certificate.'
 
 
 def test_load_certificates_bytes_from_pem_file():
@@ -85,7 +85,7 @@ def test_load_certificates_bytes_from_file_raise_file_not_found():
     with pytest.raises(X509CertificateError) as exception:
         load_certificates_bytes_from_file('path_not_found')
 
-    assert str(exception.value) == 'Certificates file not found: path_not_found'
+    assert str(exception.value) == 'Certificates file not found: path_not_found.'
 
 
 def test_load_certificates_bytes_from_file_raise_exception(mocker):
@@ -94,9 +94,7 @@ def test_load_certificates_bytes_from_file_raise_exception(mocker):
     with pytest.raises(X509CertificateError) as exception:
         load_certificates_bytes_from_file('path')
 
-    assert str(exception.value).startswith(
-        'Certificates file could not be read: Error msg'
-    )
+    assert str(exception.value) == 'Certificates file could not be read: Error msg.'
 
 
 def test_write_certificate_to_file_as_pem(tmpdir):
@@ -126,7 +124,7 @@ def test_write_certificate_to_file_raise_error(mocker):
 
     assert (
         str(exc_info.value)
-        == 'Error writing certificate to file: Could not get bytes from object: Fake Error'
+        == 'Error writing certificate to file: Could not get bytes from object: Fake Error.'
     )
 
 
@@ -170,7 +168,7 @@ def test_serialize_certificate_raise_error(mocker):
     with pytest.raises(X509CertificateError) as exc_info:
         serialize_certificate(mock_cert, serialization.Encoding.PEM)
 
-    assert str(exc_info.value) == 'Could not get bytes from object: Fake Error'
+    assert str(exc_info.value) == 'Could not get bytes from object: Fake Error.'
 
 
 def _read_bytes(filename):

--- a/test/workloadapi/test_default_workload_api_client.py
+++ b/test/workloadapi/test_default_workload_api_client.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.workloadapi.default_workload_api_client import DefaultWorkloadApiClient
 
 SPIFFE_SOCKET_ENV = 'SPIFFE_ENDPOINT_SOCKET'
@@ -9,7 +10,7 @@ WORKLOAD_API_CLIENT = DefaultWorkloadApiClient('unix:///dummy.path')
 
 # No SPIFFE_ENDPOINT_SOCKET, and no path passed, raises exception
 def test_instantiate_default_without_var():
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         DefaultWorkloadApiClient()
 
     assert (
@@ -35,7 +36,7 @@ def test_instantiate_socket_path():
 # With bad SPIFFE_ENDPOINT_SOCKET, and no path passed, throws exception
 def test_instantiate_default_with_bad_var():
     os.environ[SPIFFE_SOCKET_ENV] = '/invalid'
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         DefaultWorkloadApiClient()
 
     assert (
@@ -47,7 +48,7 @@ def test_instantiate_default_with_bad_var():
 
 # With bad socket path passed
 def test_instantiate_bad_socket_path():
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         DefaultWorkloadApiClient(spiffe_socket='/invalid')
 
     assert (

--- a/test/workloadapi/test_default_workload_api_client_jwt.py
+++ b/test/workloadapi/test_default_workload_api_client_jwt.py
@@ -6,6 +6,7 @@ from test.workloadapi.test_default_workload_api_client import WORKLOAD_API_CLIEN
 
 from pyspiffe.proto.spiffe import workload_pb2
 from pyspiffe.spiffe_id.spiffe_id import SpiffeId
+from pyspiffe.exceptions import ArgumentError
 from pyspiffe.workloadapi.exceptions import FetchJwtSvidError, ValidateJwtSvidError
 
 
@@ -72,7 +73,7 @@ def test_fetch_jwt_svid_aud(mocker):
     ],
 )
 def test_fetch_jwt_svid_no_audience(test_input_audience, expected):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         WORKLOAD_API_CLIENT.fetch_jwt_svid(audiences=test_input_audience)
 
     assert str(exception.value) == expected
@@ -148,16 +149,16 @@ def test_validate_jwt_svid(mocker):
 @pytest.mark.parametrize(
     'test_input_token, test_input_audience, expected',
     [
-        (None, 'audience', 'Token cannot be empty'),
-        ('', 'audience', 'Token cannot be empty'),
-        ('token', None, 'Audience cannot be empty'),
-        ('token', '', 'Audience cannot be empty'),
+        (None, 'audience', 'Token cannot be empty.'),
+        ('', 'audience', 'Token cannot be empty.'),
+        ('token', None, 'Audience cannot be empty.'),
+        ('token', '', 'Audience cannot be empty.'),
     ],
 )
 def test_validate_jwt_svid_invalid_input(
     test_input_token, test_input_audience, expected
 ):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(ArgumentError) as exception:
         WORKLOAD_API_CLIENT.validate_jwt_svid(
             token=test_input_token,
             audience=test_input_audience,


### PR DESCRIPTION
This PR updates the errors thrown by the library to include a dot at the end of the message automatically.

The changes:
* All custom exceptions inherit from `PySpiffeError`, the top level exception for the library.
* The final dot in the message is not necessary when raising an exception.
* To be consistent in the code, the new exception `ArgumentError` is created to replace all occurrences of `ValueError`.

This way, all error messages in the code looks the same and there is no need for a final dot. I removed the final dot from all places to make things clearer.