### PR TITLE
Refactor 'save's as instance methods.

### DIFF
--- a/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
+++ b/src/pyspiffe/bundle/x509_bundle/x509_bundle.py
@@ -80,6 +80,36 @@ class X509Bundle(object):
                 return
             self._x509_authorities.remove(x509_authority)
 
+    def save(
+        self,
+        bundle_path: str,
+        encoding: serialization.Encoding,
+    ) -> None:
+        """Saves the X.509 bundle to a file in disk.
+
+        Args:
+            bundle_path: Path to the file the set of X.509 authorities will be written to.
+            encoding: Bundle encoding format, either serialization.Encoding.PEM or serialization.Encoding.DER
+
+        Raises:
+            ArgumentError: In case the encoding is not either PEM or DER (from serialization.Encoding)
+            SaveX509BundleError: In the case the file path in bundle_path cannot be open to write, or there is an error
+                                converting or writing the authorities bytes to the file.
+        """
+
+        if encoding not in [encoding.PEM, encoding.DER]:
+            raise ArgumentError(
+                'Encoding not supported: {}. Expected \'PEM\' or \'DER\''.format(
+                    encoding
+                )
+            )
+        try:
+            write_certificates_to_file(bundle_path, encoding, self._x509_authorities)
+        except Exception as err:
+            raise SaveX509BundleError(
+                'Error writing X.509 bundle to file: {}'.format(str(err))
+            )
+
     @classmethod
     def parse(cls, trust_domain: TrustDomain, bundle_bytes: bytes) -> 'X509Bundle':
         """Parses an X.509 bundle from an array of bytes containing trusted authorities as PEM blocks.
@@ -162,38 +192,3 @@ class X509Bundle(object):
         raise ArgumentError(
             'Encoding not supported: {}. Expected \'PEM\' or \'DER\''.format(encoding)
         )
-
-    @classmethod
-    def save(
-        cls,
-        x509_bundle: 'X509Bundle',
-        bundle_path: str,
-        encoding: serialization.Encoding,
-    ) -> None:
-        """Saves an X.509 bundle to a file in disk.
-
-        Args:
-            x509_bundle: Instance of 'X509Bundle' to be saved to disk
-            bundle_path: Path to the file containing a set of X.509 authorities
-            encoding: Bundle encoding format, either serialization.Encoding.PEM or serialization.Encoding.DER
-
-        Raises:
-            ArgumentError: In case the encoding is not either PEM or DER (from serialization.Encoding)
-            SaveX509BundleError: In the case the file path in bundle_path cannot be open to write, or there is an error
-                                converting or writing the authorities bytes to the file.
-        """
-
-        if encoding not in [encoding.PEM, encoding.DER]:
-            raise ArgumentError(
-                'Encoding not supported: {}. Expected \'PEM\' or \'DER\''.format(
-                    encoding
-                )
-            )
-        try:
-            write_certificates_to_file(
-                bundle_path, encoding, x509_bundle.x509_authorities()
-            )
-        except Exception as err:
-            raise SaveX509BundleError(
-                'Error writing X.509 bundle to file: {}'.format(str(err))
-            )

--- a/test/bundle/x509bundle/test_x509_bundle.py
+++ b/test/bundle/x509bundle/test_x509_bundle.py
@@ -176,7 +176,7 @@ def test_save_bundle_pem_encoded(tmpdir):
     x509_bundle = X509Bundle.parse(trust_domain, bundle_bytes)
 
     bundle_path = tmpdir.join('bundle.pem')
-    X509Bundle.save(x509_bundle, bundle_path, serialization.Encoding.PEM)
+    x509_bundle.save(bundle_path, serialization.Encoding.PEM)
 
     saved_bundle = X509Bundle.load(
         trust_domain, bundle_path, serialization.Encoding.PEM
@@ -201,7 +201,7 @@ def test_save_bundle_der_encoded(tmpdir):
     x509_bundle = X509Bundle.parse(trust_domain, bundle_bytes)
 
     bundle_path = tmpdir.join('bundle.pem')
-    X509Bundle.save(x509_bundle, bundle_path, serialization.Encoding.DER)
+    x509_bundle.save(bundle_path, serialization.Encoding.DER)
 
     saved_bundle = X509Bundle.load(
         trust_domain, bundle_path, serialization.Encoding.DER
@@ -228,7 +228,7 @@ def test_save_non_supported_encoding(tmpdir):
     bundle_path = tmpdir.join('bundle.pem')
 
     with pytest.raises(ArgumentError) as err:
-        X509Bundle.save(x509_bundle, bundle_path, serialization.Encoding.Raw)
+        x509_bundle.save(bundle_path, serialization.Encoding.Raw)
 
     assert (
         str(err.value)
@@ -237,15 +237,18 @@ def test_save_non_supported_encoding(tmpdir):
 
 
 def test_save_error_writing_bundle_to_file(mocker):
-    mock_x509_bundle = mocker.Mock(X509Bundle)
+    bundle_bytes = read_bytes('certs.pem')
+    # create the X509Bundle to be saved
+    x509_bundle = X509Bundle.parse(trust_domain, bundle_bytes)
+
+    # mocker.patch('builtins.open', side_effect=Exception('Error msg'), autospect=True)
     mocker.patch(
         'pyspiffe.bundle.x509_bundle.x509_bundle.write_certificates_to_file',
         side_effect=Exception('Error msg'),
         autospect=True,
     )
-
     with pytest.raises(SaveX509BundleError) as err:
-        X509Bundle.save(mock_x509_bundle, 'bundle_path', serialization.Encoding.PEM)
+        x509_bundle.save('bundle_path', serialization.Encoding.PEM)
 
     assert (
         str(err.value)


### PR DESCRIPTION
Refactor the `save` methods in `X509Svid` and `X509Bundle` to be an instance methods, which makes a lot more sense than having a static method to be called through the class. So now the call to save an `X509Svid` would look like:

`my_svid.save('/tmp/my_cert.pem', /tmp/my_key.pem', encoding.PEM)`

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>