### PR TITLE
Fixes wlapi.fetch_jwt_svid() to expect a response instead of a stream.

### DIFF
--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -275,14 +275,13 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
     ) -> workload_pb2.JWTSVIDResponse:
 
         try:
-            request = workload_pb2.JWTSVIDRequest()
-            request.audience.extend(audience)
-            if spiffe_id:
-                request.spiffe_id = spiffe_id
-            response = self._spiffe_workload_api_stub.FetchJWTSVID(request)
-            item = next(response)
+            req = workload_pb2.JWTSVIDRequest(
+                audience=audience,
+                spiffe_id=spiffe_id,
+            )
+            response = self._spiffe_workload_api_stub.FetchJWTSVID(req)
         except Exception as e:
             raise FetchJwtSvidError(str(e))
-        if len(item.svids) == 0:
+        if len(response.svids) == 0:
             raise FetchJwtSvidError('JWT SVID response is empty')
-        return item
+        return response


### PR DESCRIPTION
The `FetchJWTSvid()` RPC is defined to return an unary response and not a stream.
`rpc FetchJWTSVID(JWTSVIDRequest) returns (JWTSVIDResponse);`

This PR fix the code to expect a unary response.