### PR TITLE
Add missing validation in TrustDomain

### DIFF
--- a/src/pyspiffe/spiffe_id/trust_domain.py
+++ b/src/pyspiffe/spiffe_id/trust_domain.py
@@ -92,3 +92,5 @@ class TrustDomain(object):
             raise ArgumentError(EMPTY_DOMAIN_ERROR)
         if uri.port:
             raise ArgumentError('Trust domain: port is not allowed')
+        if uri.username:
+            raise ArgumentError('Trust domain: user info is not allowed')

--- a/test/spiffe_id/test_trust_domain.py
+++ b/test/spiffe_id/test_trust_domain.py
@@ -30,6 +30,7 @@ def test_valid_trust_domain(test_input, expected):
         ('spiffe:///path/element', 'Trust domain cannot be empty.'),
         ('/path/element', 'Trust domain cannot be empty.'),
         ('spiffe://domain.test:80', 'Trust domain: port is not allowed.'),
+        ('user:pass@domain.test', 'Trust domain: user info is not allowed.'),
     ],
 )
 def test_invalid_trust_domain(test_input, expected):


### PR DESCRIPTION
The parse TrustDomain method is currently allowing parsing strings that include userinfo (e.g. `user:pass@domain.test`). Added a validation to prevent that.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>