### PR TITLE
Adds logging configuration

### DIFF
--- a/src/pyspiffe/__init__.py
+++ b/src/pyspiffe/__init__.py
@@ -8,3 +8,7 @@ TODO: add usage example here
    >>>
 
 """
+import logging
+from logging import NullHandler
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -40,7 +40,10 @@ from pyspiffe.workloadapi.workload_api_client import (
     WORKLOAD_API_HEADER_VALUE,
 )
 
+_logger = logging.getLogger(__name__)
+
 __all__ = ['DefaultWorkloadApiClient']
+
 
 # GRPC Error Codes that the client will not retry on:
 #  - INVALID_ARGUMENT is not retried according to the SPIFFE spec because the request is invalid
@@ -539,7 +542,7 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
         grpc_error_code = grpc_error.code()
 
         if retry_handler and grpc_error_code not in _NON_RETRYABLE_CODES:
-            logging.error(
+            _logger.error(
                 'Error connecting to the Workload API: {}'.format(str(grpc_error_code))
             )
             retry_handler.do_retry(

--- a/src/pyspiffe/workloadapi/default_x509_source.py
+++ b/src/pyspiffe/workloadapi/default_x509_source.py
@@ -14,6 +14,8 @@ from pyspiffe.workloadapi.workload_api_client import WorkloadApiClient
 from pyspiffe.workloadapi.x509_context import X509Context
 from pyspiffe.workloadapi.x509_source import X509Source
 
+_logger = logging.getLogger(__name__)
+
 
 class DefaultX509Source(X509Source):
     """Source of X509-SVIDs and X.509 bundles maintained via the Workload API."""
@@ -108,7 +110,7 @@ class DefaultX509Source(X509Source):
             try:
                 self._client_cancel_handler.cancel()
             except Exception as err:
-                logging.exception(
+                _logger.exception(
                     'Exception canceling the Workload API client connection: {}'.format(
                         str(err)
                     )
@@ -122,10 +124,10 @@ class DefaultX509Source(X509Source):
             try:
                 svid = self._picker(x509_context.x509_svids())
             except Exception as err:
-                logging.error(
+                _logger.error(
                     'X.509 Source: error picking X.509-SVID: {}.'.format(str(err))
                 )
-                logging.error('X.509 Source: closing due to invalid state.')
+                _logger.error('X.509 Source: closing due to invalid state.')
                 self.close()
                 return
         else:
@@ -142,5 +144,5 @@ class DefaultX509Source(X509Source):
 
     @staticmethod
     def _log_error(err: Exception) -> None:
-        logging.error('X.509 Source: Workload API client error: {}.'.format(str(err)))
-        logging.error('X.509 Source: closing.')
+        _logger.error('X.509 Source: Workload API client error: {}.'.format(str(err)))
+        _logger.error('X.509 Source: closing.')


### PR DESCRIPTION
The configuration creates a new logger for the library with a `NullHandler` to avoid any message to be logged.
This allows the library to be integrated with the library's client logging configuration.

If required, a client of the library can set the log level by:
```
py_spiffe_logger = logging.getLogger('pyspiffe')
py_spiffe_logger.setLevel(logging.DEBUG)
``` 
On the other hand, inside the library we create a logger per module using:
`_logger = logging.getLogger(__name__)`

This allows us to get a logger with a name that follows the library architecture. For example, when getting a logger at `default_workload_api_client.py` we end up having a log record from a logger called `pyspiffe.workloadapi.default_workload_api_client`.

Solves https://github.com/HewlettPackard/py-spiffe/issues/95