### PR TITLE
Unify error handling on default workload API

### DIFF
--- a/src/pyspiffe/workloadapi/handle_error.py
+++ b/src/pyspiffe/workloadapi/handle_error.py
@@ -2,11 +2,14 @@ from typing import Type
 import grpc
 import functools
 
-from pyspiffe.exceptions import PySpiffeError
+from pyspiffe.exceptions import PySpiffeError, ArgumentError
 from pyspiffe.workloadapi.exceptions import WorkloadApiError
 
 
-def handle_error(error_cls: Type[PySpiffeError], default_msg: str):
+DEFAULT_WL_API_ERROR_MESSAGE = 'Could not process response from the Workload API'
+
+
+def handle_error(error_cls: Type[PySpiffeError]):
     def handler(func):
         @functools.wraps(func)
         def wrapper(*args, **kw):
@@ -14,14 +17,16 @@ def handle_error(error_cls: Type[PySpiffeError], default_msg: str):
                 return func(*args, **kw)
             except WorkloadApiError as we:
                 raise we
+            except ArgumentError as ae:
+                raise ae
             except PySpiffeError as pe:
                 raise error_cls(str(pe))
             except grpc.RpcError as rpc_error:
                 if isinstance(rpc_error, grpc.Call):
                     raise error_cls(str(rpc_error.details()))
-                raise error_cls(default_msg)
-            except Exception:
-                raise error_cls(default_msg)
+                raise error_cls(DEFAULT_WL_API_ERROR_MESSAGE)
+            except Exception as e:
+                raise error_cls(str(e))
 
         return wrapper
 

--- a/test/workloadapi/test_default_workload_api_client_fetch_x509.py
+++ b/test/workloadapi/test_default_workload_api_client_fetch_x509.py
@@ -11,7 +11,13 @@ from pyspiffe.spiffe_id.trust_domain import TrustDomain
 from pyspiffe.workloadapi.exceptions import FetchX509SvidError, FetchX509BundleError
 from test.utils.utils import read_file_bytes
 from test.workloadapi.test_default_workload_api_client import WORKLOAD_API_CLIENT
-from test.utils.utils import ResponseHolder, handle_success, handle_error, assert_error
+from test.utils.utils import (
+    ResponseHolder,
+    handle_success,
+    handle_error,
+    assert_error,
+    FakeCall,
+)
 
 TEST_CERTS_PATH = 'test/svid/x509svid/certs/{}'
 TEST_BUNDLE_PATH = 'test/bundle/x509bundle/certs/{}'
@@ -82,6 +88,20 @@ def test_fetch_x509_svid_invalid_response(mocker):
     )
 
 
+def test_fetch_x509_svid_raise_grpc_error_call(mocker):
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+        side_effect=FakeCall()
+    )
+
+    with (pytest.raises(FetchX509SvidError)) as exception:
+        WORKLOAD_API_CLIENT.fetch_x509_svid()
+
+    assert (
+        str(exception.value)
+        == 'Error fetching X.509 SVID: Error details from Workload API.'
+    )
+
+
 def test_fetch_x509_svid_raise_exception(mocker):
     WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
@@ -90,10 +110,7 @@ def test_fetch_x509_svid_raise_exception(mocker):
     with (pytest.raises(FetchX509SvidError)) as exception:
         WORKLOAD_API_CLIENT.fetch_x509_svid()
 
-    assert (
-        str(exception.value)
-        == 'Error fetching X.509 SVID: X.509 SVID response is invalid.'
-    )
+    assert str(exception.value) == 'Error fetching X.509 SVID: mocked error.'
 
 
 def test_fetch_x509_svid_corrupted_response(mocker):
@@ -194,6 +211,20 @@ def test_fetch_x509_svids_invalid_response(mocker):
     )
 
 
+def test_fetch_x509_svids_raise_grpc_error_call(mocker):
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+        side_effect=FakeCall()
+    )
+
+    with (pytest.raises(FetchX509SvidError)) as exception:
+        WORKLOAD_API_CLIENT.fetch_x509_svids()
+
+    assert (
+        str(exception.value)
+        == 'Error fetching X.509 SVID: Error details from Workload API.'
+    )
+
+
 def test_fetch_x509_svids_raise_exception(mocker):
     WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
@@ -202,10 +233,7 @@ def test_fetch_x509_svids_raise_exception(mocker):
     with (pytest.raises(FetchX509SvidError)) as exception:
         WORKLOAD_API_CLIENT.fetch_x509_svids()
 
-    assert (
-        str(exception.value)
-        == 'Error fetching X.509 SVID: X.509 SVID response is invalid.'
-    )
+    assert str(exception.value) == 'Error fetching X.509 SVID: mocked error.'
 
 
 def test_fetch_x509_svids_corrupted_response(mocker):
@@ -324,6 +352,20 @@ def test_fetch_x509_context_invalid_response(mocker):
     )
 
 
+def test_fetch_x509_context_raise_grpc_error(mocker):
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
+        side_effect=FakeCall()
+    )
+
+    with (pytest.raises(FetchX509SvidError)) as exception:
+        WORKLOAD_API_CLIENT.fetch_x509_context()
+
+    assert (
+        str(exception.value)
+        == 'Error fetching X.509 SVID: Error details from Workload API.'
+    )
+
+
 def test_fetch_x509_context_raise_exception(mocker):
     WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
         side_effect=Exception('mocked error')
@@ -332,10 +374,7 @@ def test_fetch_x509_context_raise_exception(mocker):
     with (pytest.raises(FetchX509SvidError)) as exception:
         WORKLOAD_API_CLIENT.fetch_x509_context()
 
-    assert (
-        str(exception.value)
-        == 'Error fetching X.509 SVID: X.509 SVID response is invalid.'
-    )
+    assert str(exception.value) == 'Error fetching X.509 SVID: mocked error.'
 
 
 def test_fetch_x509_context_corrupted_svid(mocker):
@@ -499,6 +538,20 @@ def test_fetch_x509_bundles_invalid_response(mocker):
     )
 
 
+def test_fetch_x509_bundles_raise_grpc_error(mocker):
+    WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
+        side_effect=FakeCall()
+    )
+
+    with (pytest.raises(FetchX509BundleError)) as exception:
+        WORKLOAD_API_CLIENT.fetch_x509_bundles()
+
+    assert (
+        str(exception.value)
+        == 'Error fetching X.509 Bundles: Error details from Workload API.'
+    )
+
+
 def test_fetch_x509_bundles_raise_exception(mocker):
     WORKLOAD_API_CLIENT._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(
         side_effect=Exception('mocked error')
@@ -507,10 +560,7 @@ def test_fetch_x509_bundles_raise_exception(mocker):
     with (pytest.raises(FetchX509BundleError)) as exception:
         WORKLOAD_API_CLIENT.fetch_x509_bundles()
 
-    assert (
-        str(exception.value)
-        == 'Error fetching X.509 Bundles: X.509 Bundles response is invalid.'
-    )
+    assert str(exception.value) == 'Error fetching X.509 Bundles: mocked error.'
 
 
 def test_fetch_x509_bundles_corrupted_bundle(mocker):

--- a/test/workloadapi/test_default_workload_api_client_jwt.py
+++ b/test/workloadapi/test_default_workload_api_client_jwt.py
@@ -234,10 +234,7 @@ def test_fetch_jwt_bundles_raise_error(mocker):
     with pytest.raises(FetchJwtBundleError) as exc_info:
         WORKLOAD_API_CLIENT.fetch_jwt_bundles()
 
-    assert (
-        str(exc_info.value)
-        == 'Error fetching JWT Bundle: Could not process response from the Workload API.'
-    )
+    assert str(exc_info.value) == 'Error fetching JWT Bundle: Mocked error.'
 
 
 def test_validate_jwt_svid(mocker):

--- a/test/workloadapi/test_handle_error.py
+++ b/test/workloadapi/test_handle_error.py
@@ -1,13 +1,13 @@
 import pytest
 import grpc
 from pyspiffe.workloadapi.handle_error import handle_error
-from pyspiffe.exceptions import PySpiffeError
+from pyspiffe.exceptions import PySpiffeError, ArgumentError
 from pyspiffe.workloadapi.exceptions import WorkloadApiError
 from test.utils.utils import FakeCall
 
 
 def test_handle_error():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_works():
         return None
 
@@ -17,7 +17,7 @@ def test_handle_error():
 
 
 def test_handle_error_on_workload_api_error():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_raises_workload_api_error():
         raise WorkloadApiError('Workload API Error')
 
@@ -27,8 +27,19 @@ def test_handle_error_on_workload_api_error():
     assert str(exc_info.value) == 'Workload API Error.'
 
 
+def test_handle_error_on_argument_error():
+    @handle_error(error_cls=PySpiffeError)
+    def func_that_raises_workload_api_error():
+        raise ArgumentError('Argument Error')
+
+    with pytest.raises(ArgumentError) as exc_info:
+        func_that_raises_workload_api_error()
+
+    assert str(exc_info.value) == 'Argument Error.'
+
+
 def test_handle_error_on_py_spiffe_error():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_raises_py_spiffe_error():
         raise PySpiffeError('PySPIFFE Error')
 
@@ -39,18 +50,18 @@ def test_handle_error_on_py_spiffe_error():
 
 
 def test_handle_error_on_grpc_error():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_raises_grpc_error():
         raise grpc.RpcError('gRPC Error')
 
     with pytest.raises(PySpiffeError) as exc_info:
         func_that_raises_grpc_error()
 
-    assert str(exc_info.value) == 'Error Msg.'
+    assert str(exc_info.value) == 'Could not process response from the Workload API.'
 
 
 def test_handle_error_on_grpc_call_error():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_raises_grpc_call_error():
         raise FakeCall()
 
@@ -61,11 +72,11 @@ def test_handle_error_on_grpc_call_error():
 
 
 def test_handle_error_on_exception():
-    @handle_error(error_cls=PySpiffeError, default_msg='Error Msg')
+    @handle_error(error_cls=PySpiffeError)
     def func_that_raises_exception():
         raise Exception('Some random message')
 
     with pytest.raises(PySpiffeError) as exc_info:
         func_that_raises_exception()
 
-    assert str(exc_info.value) == 'Error Msg.'
+    assert str(exc_info.value) == 'Some random message.'


### PR DESCRIPTION
This PRs unified the error handling on the `default_workload_api_client.py`.
This includes checking if the error response is a `grpc.Call` which contains an error Code and Details. If it is the case, the details are included in the exception thrown to the user of the library.