### PR TITLE
Add fetch_jwt_svids for workloadapi and jwtSource

### DIFF
--- a/src/pyspiffe/workloadapi/jwt_source.py
+++ b/src/pyspiffe/workloadapi/jwt_source.py
@@ -2,7 +2,7 @@
 This module defines the source for JWT Bundles and SVIDs.
 """
 from abc import ABC, abstractmethod
-from typing import Optional, Set
+from typing import Optional, Set, List
 
 
 from pyspiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
@@ -17,6 +17,13 @@ class JwtSource(ABC):
     @abstractmethod
     def get_jwt_svid(self, audiences: Set[str], subject: Optional[SpiffeId]) -> JwtSvid:
         """Returns an JWT-SVID from the source."""
+        pass
+
+    @abstractmethod
+    def get_jwt_svids(
+        self, audiences: Set[str], subject: Optional[SpiffeId]
+    ) -> List[JwtSvid]:
+        """Returns all JWT-SVIDs from the source."""
         pass
 
     @abstractmethod

--- a/src/pyspiffe/workloadapi/workload_api_client.py
+++ b/src/pyspiffe/workloadapi/workload_api_client.py
@@ -103,7 +103,7 @@ class WorkloadApiClient(ABC):
         """
 
     @abstractmethod
-    def fetch_jwt_svid(
+    def fetch_jwt_svids(
         self, audiences: Set[str], subject: Optional[SpiffeId] = None
     ) -> List[JwtSvid]:
         """Fetches all SPIFFE JWT-SVIDs.

--- a/src/pyspiffe/workloadapi/workload_api_client.py
+++ b/src/pyspiffe/workloadapi/workload_api_client.py
@@ -103,6 +103,20 @@ class WorkloadApiClient(ABC):
         """
 
     @abstractmethod
+    def fetch_jwt_svid(
+        self, audiences: Set[str], subject: Optional[SpiffeId] = None
+    ) -> List[JwtSvid]:
+        """Fetches all SPIFFE JWT-SVIDs.
+
+        Args:
+            audiences: Set of audiences for the JWT SVID.
+            subject: SPIFFE ID subject for the JWT SVID.
+
+        Returns:
+            JwtSvid: List of JwtSvid object.
+        """
+
+    @abstractmethod
     def fetch_jwt_bundles(self) -> JwtBundleSet:
         """Fetches the JWT bundles for JWT-SVID validation, keyed by trust
         domain.


### PR DESCRIPTION
Signed-off-by: Yuhan Li <liyuhan.loveyana@bytedance.com>

Add fetch_jwt_svids method for workloadapi to fetch all jwt-svids, which are provided to the client side for filtering under workload scenarios with multiple registration information.

Related: https://github.com/spiffe/go-spiffe/pull/187