### PR TITLE
Add a fix to the error raised when using empty spiffeID in fetch_jwt_…

### DIFF
--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -279,10 +279,13 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
         if not audiences:
             raise ArgumentError('Parameter audiences cannot be empty')
 
+        if subject != None:
+            subject = str(subject)
+
         response = self._spiffe_workload_api_stub.FetchJWTSVID(
             request=workload_pb2.JWTSVIDRequest(
                 audience=audiences,
-                spiffe_id=str(subject),
+                spiffe_id=subject,
             )
         )
 

--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -283,7 +283,7 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
         response = self._spiffe_workload_api_stub.FetchJWTSVID(
             request=workload_pb2.JWTSVIDRequest(
                 audience=audiences,
-                spiffe_id=subject,
+                spiffe_id=subject_str,
             )
         )
 

--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -279,9 +279,7 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
         if not audiences:
             raise ArgumentError('Parameter audiences cannot be empty')
 
-        if subject is not None:
-            subject = str(subject)
-
+        subject_str = str(subject) if subject is not None else ''
         response = self._spiffe_workload_api_stub.FetchJWTSVID(
             request=workload_pb2.JWTSVIDRequest(
                 audience=audiences,

--- a/src/pyspiffe/workloadapi/default_workload_api_client.py
+++ b/src/pyspiffe/workloadapi/default_workload_api_client.py
@@ -279,7 +279,7 @@ class DefaultWorkloadApiClient(WorkloadApiClient):
         if not audiences:
             raise ArgumentError('Parameter audiences cannot be empty')
 
-        if subject != None:
+        if subject is not None:
             subject = str(subject)
 
         response = self._spiffe_workload_api_stub.FetchJWTSVID(


### PR DESCRIPTION
…svid

Modifying this part :

```python
    @handle_error(error_cls=FetchJwtSvidError)
    def fetch_jwt_svid(
        self, audiences: List[str], subject: Optional[SpiffeId] = None
    ) -> JwtSvid:
        if not audiences:
            raise ArgumentError('Parameter audiences cannot be empty')
       
        response = self._spiffe_workload_api_stub.FetchJWTSVID(
            request=workload_pb2.JWTSVIDRequest(
                audience=audiences,
                spiffe_id=str(subject),
            )
        )

        if len(response.svids) == 0:
            raise FetchJwtSvidError('JWT SVID response is empty')

        svid = response.svids[0].svid
        return JwtSvid.parse_insecure(svid, audiences)
```

Bug :

When using fetch_jwt_svid with no spiffeID specified it raises a `FetchJwtSvidError` while it shouldn't.

Cause :

```
spiffe_id=str(subject),
```

parsing a `None` object as a str creates `'None'`, causing the next function (`JWTSVIDRequest`) to consider having a specified spiffeID when None has been specified, handled by the `@handle_error` as a `FetchJwtSvidError`.

Fix :

Handling the NoneType before, by casting `subject` to a `str` only if it's not None.


```
        if subject != None:
            subject = str(subject)
```