### PR TITLE
Adjusting  Retry Max Delay default value to 5 seconds.

### DIFF
--- a/spiffe/src/spiffe/workloadapi/workload_api_client.py
+++ b/spiffe/src/spiffe/workloadapi/workload_api_client.py
@@ -75,7 +75,7 @@ class RetryHandler:
         max_retries: int = UNLIMITED_RETRIES,
         base_backoff_in_seconds: float = 0.1,
         backoff_factor: int = 2,
-        max_delay_in_seconds: float = 60,
+        max_delay_in_seconds: float = 5,
     ) -> None:
         """Creates a RetryHandler that keeps track of retries and allows the execution of a callable using an
            exponential backoff policy.


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/HewlettPackard/py-spiffe/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

Adjusting  Retry Max Delay default value to 5 seconds.

Given the context of the Workload API listening on a local socket and likely serving a limited number of workloads, adjusting the Retry Max Delay default value to a more reasonable value, such as 5 seconds, can enhance efficiency and responsiveness. This adjustment acknowledges the balance between providing timely updates and not overly taxing the system resources or flooding the Workload API with requests during periods of rapid changes or temporary issues.


**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->