### PR TITLE
Automate PyPI Publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'spiffe-*'
+      - 'spiffe-tls-*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      # Conditional step for spiffe module
+      - name: Publish spiffe
+        if: startsWith(github.ref, 'refs/tags/spiffe-')
+        run: |
+          cd spiffe
+          make all
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_TOKEN }}
+
+      # Conditional step for spiffe-tls module
+      - name: Publish spiffe-tls
+        if: startsWith(github.ref, 'refs/tags/spiffe-tls-')
+        run: |
+          cd spiffe-tls
+          make all 
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/HewlettPackard/py-spiffe/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

This PR introduces a GitHub Actions workflow for automated publishing of the spiffe and spiffe-tls Python modules to PyPI. It triggers on tags `spiffe-*` and `spiffe-tls-*`, using conditional logic to publish the relevant module based on the tag. The workflow employs Poetry for packaging and leverages GitHub Secrets for secure PyPI authentication.

Features:

- Tag-based Triggers: Initiates publishing based on spiffe-* or spiffe-tls-* tags.
- Conditional Publishing: Determines which module to publish based on the tag prefix.
- Secure & Automated: Uses stored PyPI credentials for secure, automated publishing.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->