### PR TITLE
fix(spiffe): require protobuf >=6.31.1 to match generated gencode

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.5] – 2026-03-07
+
+### Fixed
+- Raised protobuf runtime requirement to `>=6.31.1,<8` to prevent gencode/runtime mismatches with checked-in generated protobuf code (e.g. gencode 6.31.1 with runtime 5.x).
+
+
 ## [0.2.4] – 2026-02-24
 
 ### Fixed

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pyasn1>=0.6.0,<0.7.0",
   "pyasn1-modules>=0.4.0,<0.5.0",
   "pem>=23,<24",
-  "protobuf>=5,<8",
+  "protobuf>=6.31.1,<8",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -918,7 +918,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45,<47" },
     { name = "grpcio", specifier = ">=1.62,<2" },
     { name = "pem", specifier = ">=23,<24" },
-    { name = "protobuf", specifier = ">=5,<7" },
+    { name = "protobuf", specifier = ">=6.31.1,<8" },
     { name = "pyasn1", specifier = ">=0.6.0,<0.7.0" },
     { name = "pyasn1-modules", specifier = ">=0.4.0,<0.5.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2,<2.12" },


### PR DESCRIPTION
## Summary
- Raise `spiffe` runtime dependency from `protobuf>=5,<8` to `protobuf>=6.31.1,<8`.
- Regenerate `uv.lock` so resolved metadata reflects the new protobuf floor.
- Prevent runtime/gencode incompatibility errors when importing generated protobuf modules (`workload_pb2` generated with protobuf 6.31.1).

## Why
A user reported #397:
`Detected incompatible Protobuf Gencode/Runtime versions ... gencode 6.31.1 runtime 5.29.6`.

The package metadata previously allowed protobuf 5.x, which can be older than the checked-in generated code's required runtime. This change enforces a compatible minimum at install time.

## Test plan
- [x] Fresh venv install from local package path:
  - `pip install "spiffe @ file:///.../spiffe"`
  - Verify `from spiffe._proto import workload_pb2` imports successfully.
- [x] Forced bad runtime scenario:
  - Preinstall `protobuf==5.29.6`, then install `spiffe`.
  - Confirm resolver upgrades protobuf to a compatible version (`>=6.31.1`).
  - Re-verify `workload_pb2` import succeeds.
- [x] Run `pip check` in both scenarios to confirm no broken requirements.

## Impact
- Fixes a real packaging/runtime compatibility issue for users who otherwise resolve protobuf 5.x.
- No API changes.