### PR TITLE
fix(tooling): exclude virtualenv and cache dirs from copyright script

### DIFF
--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -17,7 +17,16 @@ under the License.
 import os
 
 FORBIDDEN_FILES = ["__init__.py"]
-FORBIDDEN_DIRECTORIES = ["proto"]
+FORBIDDEN_DIRECTORIES = [
+    "proto",
+    ".git",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+]
 COPYRIGHT_TEXT = """\"\"\"
 (C) Copyright 2021 Hewlett Packard Enterprise Development LP
 


### PR DESCRIPTION
## Summary
- Update `scripts/copyright.py` to skip non-source directories during traversal.
- Add exclusions for `.venv`, `venv`, `.git`, `__pycache__`, `.mypy_cache`, `.pytest_cache`, and `.ruff_cache`.

## Why
The script was scanning the repository root recursively and could modify files inside `.venv` (installed tooling like `pluggy`/`mypy`), corrupting those packages and breaking pre-commit/commit flows with syntax errors.

## Test plan
- [x] Recreate env: `rm -rf .venv && uv sync --all-packages`
- [x] Run hooks: `uv run pre-commit run --all-files`
- [x] Verify hooks pass and tooling remains executable