### PR TITLE
fix: reject X.509-SVID leaf SPIFFE IDs with root path

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 ### Changed
-- In `X509Svid.parse()` and `X509Svid.parse_raw()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.
+- Tightened `X509Svid` leaf SPIFFE ID validation to reject trust-domain root IDs in leaf certificates (a non-empty path is required).
+- In `X509Svid.parse()`, `X509Svid.parse_raw()`, and `X509Svid.load()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both the leaf SPIFFE ID and private key are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.
 
 ## [0.2.6] – 2026-03-15
 

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- In `X509Svid.parse()` and `X509Svid.parse_raw()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.
+
 ## [0.2.6] – 2026-03-15
 
 ### Fixed

--- a/spiffe/src/spiffe/svid/x509_svid.py
+++ b/spiffe/src/spiffe/svid/x509_svid.py
@@ -159,9 +159,10 @@ class X509Svid(object):
             ParsePrivateKeyError: In case the private key cannot be parsed from the private_key_bytes.
             InvalidLeafCertificateError: In case the leaf certificate does not have a SPIFFE ID in the URI SAN,
                                          in case the leaf certificate is CA,
+                                         in case the leaf certificate has a SPIFFE ID with a root path,
                                          in case the leaf certificate has 'keyCertSign' as key usage,
                                          in case the leaf certificate does not have 'digitalSignature' as key usage,
-                                         in case the leaf certificate does not have 'cRLSign' as key usage.
+                                         in case the leaf certificate has 'cRLSign' as key usage.
             InvalidIntermediateCertificateError: In case one of the intermediate certificates is not CA,
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """
@@ -199,9 +200,10 @@ class X509Svid(object):
             ParsePrivateKeyError: In case the private key cannot be parsed from the private_key_bytes.
             InvalidLeafCertificateError: In case the leaf certificate does not have a SPIFFE ID in the URI SAN,
                                          in case the leaf certificate is CA,
+                                         in case the leaf certificate has a SPIFFE ID with a root path,
                                          in case the leaf certificate has 'keyCertSign' as key usage,
                                          in case the leaf certificate does not have 'digitalSignature' as key usage,
-                                         in case the leaf certificate does not have 'cRLSign' as key usage.
+                                         in case the leaf certificate has 'cRLSign' as key usage.
             InvalidIntermediateCertificateError: In case one of the intermediate certificates is not CA,
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """
@@ -246,9 +248,10 @@ class X509Svid(object):
             ParsePrivateKeyError: In case the private key cannot be parsed from the bytes read from private_key_path.
             InvalidLeafCertificateError: In case the leaf certificate does not have a SPIFFE ID in the URI SAN,
                                          in case the leaf certificate is CA,
+                                         in case the leaf certificate has a SPIFFE ID with a root path,
                                          in case the leaf certificate has 'keyCertSign' as key usage,
                                          in case the leaf certificate does not have 'digitalSignature' as key usage,
-                                         in case the leaf certificate does not have 'cRLSign' as key usage.
+                                         in case the leaf certificate has 'cRLSign' as key usage.
             InvalidIntermediateCertificateError: In case one of the intermediate certificates is not CA,
                                                  in case one of the intermediate certificates does not have 'keyCertSign' as key usage.
         """

--- a/spiffe/src/spiffe/svid/x509_svid.py
+++ b/spiffe/src/spiffe/svid/x509_svid.py
@@ -170,12 +170,9 @@ class X509Svid(object):
         chain = parse_der_certificates(certs_chain_bytes)
         _validate_chain(chain)
 
-        private_key = parse_der_private_key(private_key_bytes)
         spiffe_id = _extract_spiffe_id(chain[0])
-        if not spiffe_id.path:
-            raise InvalidLeafCertificateError(
-                'Leaf certificate SPIFFE ID must have a non-root path'
-            )
+        _validate_leaf_spiffe_id(spiffe_id)
+        private_key = parse_der_private_key(private_key_bytes)
 
         return X509Svid(spiffe_id, chain, private_key)
 
@@ -211,12 +208,9 @@ class X509Svid(object):
         chain = parse_pem_certificates(certs_chain_bytes)
         _validate_chain(chain)
 
-        private_key = parse_pem_private_key(private_key_bytes)
         spiffe_id = _extract_spiffe_id(chain[0])
-        if not spiffe_id.path:
-            raise InvalidLeafCertificateError(
-                'Leaf certificate SPIFFE ID must have a non-root path'
-            )
+        _validate_leaf_spiffe_id(spiffe_id)
+        private_key = parse_pem_private_key(private_key_bytes)
 
         return X509Svid(spiffe_id, chain, private_key)
 
@@ -316,6 +310,13 @@ def _validate_chain(cert_chain: List[Certificate]) -> None:
 
     for cert in cert_chain[1:]:
         _validate_intermediate_certificate(cert)
+
+
+def _validate_leaf_spiffe_id(spiffe_id: SpiffeId) -> None:
+    if not spiffe_id.path:
+        raise InvalidLeafCertificateError(
+            'Leaf certificate SPIFFE ID must have a non-root path'
+        )
 
 
 def _validate_leaf_certificate(leaf: Certificate) -> None:

--- a/spiffe/src/spiffe/svid/x509_svid.py
+++ b/spiffe/src/spiffe/svid/x509_svid.py
@@ -315,7 +315,7 @@ def _validate_chain(cert_chain: List[Certificate]) -> None:
 def _validate_leaf_spiffe_id(spiffe_id: SpiffeId) -> None:
     if not spiffe_id.path:
         raise InvalidLeafCertificateError(
-            'Leaf certificate SPIFFE ID must have a non-root path'
+            'Leaf certificate SPIFFE ID must not be a trust domain root (a path component is required)'
         )
 
 

--- a/spiffe/src/spiffe/svid/x509_svid.py
+++ b/spiffe/src/spiffe/svid/x509_svid.py
@@ -171,6 +171,10 @@ class X509Svid(object):
 
         private_key = parse_der_private_key(private_key_bytes)
         spiffe_id = _extract_spiffe_id(chain[0])
+        if not spiffe_id.path:
+            raise InvalidLeafCertificateError(
+                'Leaf certificate SPIFFE ID must have a non-root path'
+            )
 
         return X509Svid(spiffe_id, chain, private_key)
 
@@ -207,6 +211,10 @@ class X509Svid(object):
 
         private_key = parse_pem_private_key(private_key_bytes)
         spiffe_id = _extract_spiffe_id(chain[0])
+        if not spiffe_id.path:
+            raise InvalidLeafCertificateError(
+                'Leaf certificate SPIFFE ID must have a non-root path'
+            )
 
         return X509Svid(spiffe_id, chain, private_key)
 

--- a/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
+++ b/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
@@ -700,7 +700,7 @@ def test_parse_rejects_root_path_spiffe_id_in_leaf() -> None:
 
     assert (
         str(exc.value)
-        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must have a non-root path'
+        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must not be a trust domain root (a path component is required)'
     )
 
 
@@ -724,7 +724,37 @@ def test_parse_raw_rejects_root_path_spiffe_id_in_leaf() -> None:
 
     assert (
         str(exc.value)
-        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must have a non-root path'
+        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must not be a trust domain root (a path component is required)'
+    )
+
+
+def test_load_rejects_root_path_spiffe_id_in_leaf(tmpdir: str) -> None:
+    """
+    Load path should reject leaf SPIFFE IDs that point to the trust domain root.
+    """
+    cert, key = _make_cert(
+        uri_sans=["spiffe://example.org"],
+        dns_sans=[],
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    chain_file = tmpdir.join('chain.pem')
+    key_file = tmpdir.join('key.pem')
+    with open(chain_file, "wb") as f:
+        f.write(cert_pem)
+    with open(key_file, "wb") as f:
+        f.write(key_pem)
+
+    with pytest.raises(InvalidLeafCertificateError) as exc:
+        X509Svid.load(chain_file, key_file, serialization.Encoding.PEM)
+
+    assert (
+        str(exc.value)
+        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must not be a trust domain root (a path component is required)'
     )
 
 

--- a/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
+++ b/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
@@ -680,6 +680,48 @@ def test_extract_spiffe_id_allows_dns_sans_with_single_spiffe_uri_san() -> None:
     assert _extract_spiffe_id(cert) == SpiffeId("spiffe://example.org/service")
 
 
+def test_parse_rejects_root_path_spiffe_id_in_leaf() -> None:
+    """
+    Leaf SPIFFE ID must not be the trust domain root (empty path).
+    """
+    cert, key = _make_cert(
+        uri_sans=["spiffe://example.org"],
+        dns_sans=[],
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    with pytest.raises(InvalidLeafCertificateError) as exc:
+        X509Svid.parse(cert_pem, key_pem)
+
+    assert 'Leaf certificate SPIFFE ID must have a non-root path' in str(exc.value)
+
+
+def test_parse_raw_rejects_root_path_spiffe_id_in_leaf() -> None:
+    """
+    DER parse path must enforce the same non-root SPIFFE ID rule for leaf certificates.
+    """
+    cert, key = _make_cert(
+        uri_sans=["spiffe://example.org"],
+        dns_sans=[],
+    )
+    cert_der = cert.public_bytes(serialization.Encoding.DER)
+    key_der = key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    with pytest.raises(InvalidLeafCertificateError) as exc:
+        X509Svid.parse_raw(cert_der, key_der)
+
+    assert 'Leaf certificate SPIFFE ID must have a non-root path' in str(exc.value)
+
+
 def test_parse_rejects_multiple_uri_sans_even_if_one_is_spiffe() -> None:
     """
     End-to-end parse path should enforce the same URI SAN cardinality rule.

--- a/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
+++ b/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
@@ -698,7 +698,10 @@ def test_parse_rejects_root_path_spiffe_id_in_leaf() -> None:
     with pytest.raises(InvalidLeafCertificateError) as exc:
         X509Svid.parse(cert_pem, key_pem)
 
-    assert 'Leaf certificate SPIFFE ID must have a non-root path' in str(exc.value)
+    assert (
+        str(exc.value)
+        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must have a non-root path'
+    )
 
 
 def test_parse_raw_rejects_root_path_spiffe_id_in_leaf() -> None:
@@ -719,7 +722,10 @@ def test_parse_raw_rejects_root_path_spiffe_id_in_leaf() -> None:
     with pytest.raises(InvalidLeafCertificateError) as exc:
         X509Svid.parse_raw(cert_der, key_der)
 
-    assert 'Leaf certificate SPIFFE ID must have a non-root path' in str(exc.value)
+    assert (
+        str(exc.value)
+        == 'Invalid leaf certificate: Leaf certificate SPIFFE ID must have a non-root path'
+    )
 
 
 def test_parse_rejects_multiple_uri_sans_even_if_one_is_spiffe() -> None:


### PR DESCRIPTION
## Summary

Enforces X.509-SVID spec: `Updates X509Svid.parse` and `X509Svid.parse_raw` so that leaf certificates are rejected when their URI SAN is a SPIFFE ID with an empty/root path (e.g. spiffe://example.org).
Leaf-only restriction: The new check runs only on the extracted SPIFFE ID for the leaf certificate; intermediate/CA certificates are unaffected.
Error semantics: When a leaf SPIFFE ID has no path, `InvalidLeafCertificateError` is raised with the message: Invalid leaf certificate: Leaf certificate SPIFFE ID must have a non-root path.
