### PR TITLE
fix(jwt-bundle): extract only jwt-svid JWK authorities

### DIFF
--- a/spiffe/src/spiffe/bundle/jwt_bundle/jwt_bundle.py
+++ b/spiffe/src/spiffe/bundle/jwt_bundle/jwt_bundle.py
@@ -22,7 +22,7 @@ import threading
 from json import JSONDecodeError
 from jwt.api_jwk import PyJWKSet
 from jwt.exceptions import InvalidKeyError, PyJWKSetError
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, get_args
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, dsa, ed25519, ed448
 
 from spiffe.spiffe_id.spiffe_id import TrustDomain
@@ -36,6 +36,8 @@ _PUBLIC_KEY_TYPES = Union[
     ed25519.Ed25519PublicKey,
     ed448.Ed448PublicKey,
 ]
+
+_PUBLIC_KEY_TYPE_VALUES = get_args(_PUBLIC_KEY_TYPES)
 
 
 class JwtBundle(object):
@@ -121,10 +123,26 @@ class JwtBundle(object):
 
             jwt_authorities = {}
             for jwk in jwks.keys:
+                # SPIFFE bundles may contain JWK entries for multiple SVID types.
+                # For JWT-SVID validation we must only extract keys explicitly
+                # marked as `use == "jwt-svid"`, with a non-empty `kid`.
+                jwk_use = None
+                jwk_data = getattr(jwk, '_jwk_data', None)
+                if isinstance(jwk_data, dict):
+                    jwk_use = jwk_data.get('use')
+                else:
+                    jwk_use = getattr(jwk, 'use', None)
+                if jwk_use != 'jwt-svid':
+                    continue
+
                 if not jwk.key_id:
                     raise ParseJWTBundleError(
                         'Error adding authority from JWKS: "keyID" cannot be empty'
                     )
+
+                # Only accept public key types we know how to handle.
+                if not isinstance(jwk.key, _PUBLIC_KEY_TYPE_VALUES):
+                    continue
 
                 jwt_authorities[jwk.key_id] = jwk.key
 

--- a/spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py
+++ b/spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py
@@ -14,6 +14,7 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
+import json
 import pytest
 from typing import Dict
 from pytest_mock import MockerFixture
@@ -167,4 +168,47 @@ def test_parse_jwks_with_null_keys_field() -> None:
     bundle = JwtBundle.parse(trust_domain, jwks_null_keys_bytes)
 
     assert bundle
+    assert len(bundle.jwt_authorities) == 0
+
+
+def test_parse_ignores_x509_svid_jwks_entries() -> None:
+    jwks_obj = json.loads(JWKS_1_EC_KEY.decode('utf-8'))
+    jwks_obj['keys'][0]['use'] = 'x509-svid'
+    jwks_bytes = json.dumps(jwks_obj).encode('utf-8')
+
+    bundle = JwtBundle.parse(trust_domain, jwks_bytes)
+    assert len(bundle.jwt_authorities) == 0
+
+
+def test_parse_ignores_jwks_entries_missing_use() -> None:
+    jwks_obj = json.loads(JWKS_1_EC_KEY.decode('utf-8'))
+    jwks_obj['keys'][0].pop('use', None)
+    jwks_bytes = json.dumps(jwks_obj).encode('utf-8')
+
+    bundle = JwtBundle.parse(trust_domain, jwks_bytes)
+    assert len(bundle.jwt_authorities) == 0
+
+
+def test_parse_jwks_mixed_entries_extracts_only_jwt_svid_keys() -> None:
+    jwks_obj = json.loads(JWKS_2_EC_1_RSA_KEYS.decode('utf-8'))
+    keys = jwks_obj['keys']
+
+    jwt_svid_kid = keys[0]['kid']
+    keys[0]['use'] = 'jwt-svid'
+    keys[1]['use'] = 'x509-svid'
+    keys[2].pop('use', None)
+
+    jwks_bytes = json.dumps(jwks_obj).encode('utf-8')
+    bundle = JwtBundle.parse(trust_domain, jwks_bytes)
+
+    assert set(bundle.jwt_authorities.keys()) == {jwt_svid_kid}
+
+
+def test_parse_does_not_fail_on_non_jwt_svid_entry_missing_kid() -> None:
+    jwks_obj = json.loads(JWKS_MISSING_KEY_ID.decode('utf-8'))
+    for key in jwks_obj['keys']:
+        key['use'] = 'x509-svid'
+    jwks_bytes = json.dumps(jwks_obj).encode('utf-8')
+
+    bundle = JwtBundle.parse(trust_domain, jwks_bytes)
     assert len(bundle.jwt_authorities) == 0

--- a/testutils/src/testutils/jwks/jwks_1_ec_key.json
+++ b/testutils/src/testutils/jwks/jwks_1_ec_key.json
@@ -3,6 +3,7 @@
         {
             "kty": "EC",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "use": "jwt-svid",
             "crv": "P-256",
             "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
             "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"

--- a/testutils/src/testutils/jwks/jwks_3_keys.json
+++ b/testutils/src/testutils/jwks/jwks_3_keys.json
@@ -3,6 +3,7 @@
         {
             "kty": "EC",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "use": "jwt-svid",
             "crv": "P-256",
             "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
             "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
@@ -10,6 +11,7 @@
         {
             "kty": "EC",
             "kid": "gHTCunJbefYtnZnTctd84xeRWyMrEsWD",
+            "use": "jwt-svid",
             "crv": "P-256",
             "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
             "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"
@@ -17,6 +19,7 @@
         {
             "kty":"RSA",
             "kid":"2011-04-29",
+            "use":"jwt-svid",
             "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
             "e":"AQAB"
          }

--- a/testutils/src/testutils/jwks/jwks_ec_missing_x.json
+++ b/testutils/src/testutils/jwks/jwks_ec_missing_x.json
@@ -3,6 +3,7 @@
         {
             "kty": "EC",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+            "use": "jwt-svid",
             "crv": "P-256",
             "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
         }

--- a/testutils/src/testutils/jwks/jwks_missing_kid.json
+++ b/testutils/src/testutils/jwks/jwks_missing_kid.json
@@ -9,6 +9,7 @@
         },
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "crv": "P-256",
             "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
             "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"


### PR DESCRIPTION
## What
Update `JwtBundle.parse` to include only JWKs marked for JWT-SVID validation (`use == "jwt-svid`") with a non-empty kid as JWT authorities, ignoring other use values and missing/unknown use entries.

## Why
SPIFFE JWT bundle semantics require extracting only jwt-svid keys for JWT-SVID validation. The previous implementation loaded all JWKs, which could incorrectly treat non-JWT-SVID keys as JWT signing authorities.

## How tested

- spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py
- spiffe/tests/unit/workloadapi/test_jwt_source.py 
- spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py

Backward-incompatibility note: Bundles that previously “worked” due to missing/absent use or non-jwt-svid use entries being loaded as JWT authorities will now ignore those keys (fail-closed for invalid JWT authorities remains unchanged).