### PR TITLE
fix(spiffe_id): accept mixed-case SPIFFE scheme and trust domain

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 - Tightened `X509Svid` leaf SPIFFE ID validation to reject trust-domain root IDs in leaf certificates (a non-empty path is required).
 - In `X509Svid.parse()`, `X509Svid.parse_raw()`, and `X509Svid.load()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both the leaf SPIFFE ID and private key are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.
+- Accept mixed-case SPIFFE URI scheme and trust domain input during `SpiffeId`/`TrustDomain` parsing, while canonicalizing trust domains to lowercase output.
+- Allow underscore (`_`) in trust-domain labels (for example `trust_domain_1.example.org`) to align trust-domain validation with SPIFFE ID spec section 2.1.
 
 ## [0.2.6] – 2026-03-15
 

--- a/spiffe/src/spiffe/spiffe_id/spiffe_id.py
+++ b/spiffe/src/spiffe/spiffe_id/spiffe_id.py
@@ -23,6 +23,12 @@ This module manages SpiffeId and TrustDomain objects.
 """
 
 SCHEME_PREFIX = "spiffe://"
+_SCHEME_LEN = len(SCHEME_PREFIX)
+
+
+def _has_spiffe_scheme(s: str) -> bool:
+    """True if ``s`` begins with the SPIFFE URI scheme (case-insensitive)."""
+    return len(s) >= _SCHEME_LEN and s[:_SCHEME_LEN].lower() == SCHEME_PREFIX
 
 
 class SpiffeIdError(PySpiffeError):
@@ -65,8 +71,9 @@ class TrustDomain:
     """
     Represents the name of a SPIFFE Trust Domain.
 
-    The TrustDomain can be initialized with a name or a full SPIFFE ID, from
-    which the trust domain part is extracted.
+    Trust domain names are stored in lowercase canonical form; input may use
+    mixed case in the domain labels. The TrustDomain can be initialized with a
+    name or a full SPIFFE ID, from which the trust domain part is extracted.
 
     Examples:
         >>> td = TrustDomain("example.org")
@@ -107,8 +114,9 @@ class SpiffeId:
     Represents a SPIFFE Identifier according to the SPIFFE standard.
 
     A SPIFFE ID is composed of a scheme ('spiffe'), a trust domain, and a path.
-    It uniquely identifies a workload within a trust domain. The path is
-    optional and is used to identify specific entities within the trust domain.
+    The scheme and trust domain are matched case-insensitively on input; the
+    trust domain is normalized to lowercase. The path is case-sensitive and
+    preserved exactly as provided.
 
     Examples:
         Creating a SpiffeId with a path:
@@ -126,10 +134,10 @@ class SpiffeId:
         if not id:
             raise SpiffeIdError("cannot be empty")
 
-        if not id.startswith(SCHEME_PREFIX):
+        if not _has_spiffe_scheme(id):
             raise SpiffeIdError("does not start with 'spiffe://'", id)
 
-        rest = id[len(SCHEME_PREFIX) :]
+        rest = id[_SCHEME_LEN:]
         path_idx = rest.find("/")
         if path_idx == -1:
             # No path found; entire `rest` is the trust domain
@@ -193,14 +201,21 @@ class SpiffeId:
 
 
 def extract_and_validate_trust_domain(id_or_name: str) -> str:
-    if ":/" in id_or_name:
-        if not id_or_name.startswith(SCHEME_PREFIX):
+    """Return the trust domain in lowercase canonical form.
+
+    Accepts a bare hostname-style name or a ``spiffe://`` URI (scheme
+    case-insensitive); SPIFFE ID form must use ``://`` after the scheme.
+    """
+    if "://" in id_or_name:
+        if not _has_spiffe_scheme(id_or_name):
             raise TrustDomainError("ID form does not start with 'spiffe://'", id_or_name)
-        trust_domain = id_or_name[len(SCHEME_PREFIX) :].split("/", 1)[0]
+        trust_domain = id_or_name[_SCHEME_LEN:].split("/", 1)[0]
     else:
         trust_domain = id_or_name
 
-    # Validate trust domain
+    trust_domain = trust_domain.lower()
+
+    # Validate trust domain (after lowercase canonicalization)
     if not trust_domain:
         raise TrustDomainError("cannot be empty")
 

--- a/spiffe/src/spiffe/spiffe_id/spiffe_id.py
+++ b/spiffe/src/spiffe/spiffe_id/spiffe_id.py
@@ -226,7 +226,7 @@ def extract_and_validate_trust_domain(id_or_name: str) -> str:
         raise TrustDomainError("cannot contain consecutive dots", id_or_name)
 
     if not re.match(
-        r'^[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*$',
+        r'^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-_]*[a-z0-9])?)*$',
         trust_domain,
     ):
         raise TrustDomainError("contains disallowed characters", id_or_name)

--- a/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
+++ b/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
@@ -151,6 +151,7 @@ def test_spiffe_id_path_case_preserved() -> None:
 
 def test_spiffe_id_equivalent_inputs_equal() -> None:
     assert SpiffeId("spiffe://example.org/p") == SpiffeId("SPIFFE://EXAMPLE.ORG/p")
+    assert SpiffeId("spiffe://example.org/Service") != SpiffeId("spiffe://example.org/service")
 
 
 def test_spiffe_id_invalid_trust_domain_chars_after_normalization() -> None:

--- a/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
+++ b/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
@@ -113,3 +113,46 @@ def test_spiffe_id_hash_equality() -> None:
 def test_spiffe_id_string_representation() -> None:
     id = SpiffeId("spiffe://example.org/path")
     assert str(id) == "spiffe://example.org/path"
+
+
+@pytest.mark.parametrize(
+    "id_input, expected_str, expected_td",
+    [
+        (
+            "SPIFFE://example.org/service",
+            "spiffe://example.org/service",
+            "example.org",
+        ),
+        (
+            "spiffe://EXAMPLE.ORG/service",
+            "spiffe://example.org/service",
+            "example.org",
+        ),
+        (
+            "SpIfFe://Example.Org/service",
+            "spiffe://example.org/service",
+            "example.org",
+        ),
+    ],
+)
+def test_spiffe_id_scheme_and_trust_domain_case_insensitive(
+    id_input: str, expected_str: str, expected_td: str
+) -> None:
+    sid = SpiffeId(id_input)
+    assert str(sid) == expected_str
+    assert sid.trust_domain.name == expected_td
+
+
+def test_spiffe_id_path_case_preserved() -> None:
+    sid = SpiffeId("SPIFFE://example.org/Service/API")
+    assert sid.path == "/Service/API"
+    assert str(sid) == "spiffe://example.org/Service/API"
+
+
+def test_spiffe_id_equivalent_inputs_equal() -> None:
+    assert SpiffeId("spiffe://example.org/p") == SpiffeId("SPIFFE://EXAMPLE.ORG/p")
+
+
+def test_spiffe_id_invalid_trust_domain_chars_after_normalization() -> None:
+    with pytest.raises(SpiffeIdError):
+        SpiffeId("SPIFFE://Example$.Org/path")

--- a/spiffe/tests/unit/spiffe_id/test_trust_domain.py
+++ b/spiffe/tests/unit/spiffe_id/test_trust_domain.py
@@ -23,6 +23,7 @@ from spiffe.spiffe_id.spiffe_id import TrustDomain, TrustDomainError
     "input,expected",
     [
         ("example.org", "example.org"),
+        ("trust_domain_1.example.org", "trust_domain_1.example.org"),
         ("spiffe://example.org/service", "example.org"),
         ("spiffe://example.org", "example.org"),
         ("domain.test", "domain.test"),
@@ -114,6 +115,7 @@ def test_trust_domain_canonical_lowercase_regression() -> None:
     a = TrustDomain("ExAmPlE.oRg")
     b = TrustDomain("example.org")
     assert str(a) == "example.org"
+    assert a != "EXAMPLE.ORG"
     assert a == b
     assert a == "example.org"
     assert hash(a) == hash(b)

--- a/spiffe/tests/unit/spiffe_id/test_trust_domain.py
+++ b/spiffe/tests/unit/spiffe_id/test_trust_domain.py
@@ -27,6 +27,10 @@ from spiffe.spiffe_id.spiffe_id import TrustDomain, TrustDomainError
         ("spiffe://example.org", "example.org"),
         ("domain.test", "domain.test"),
         ("a.b.c.d.e.f", "a.b.c.d.e.f"),
+        ("Example.Org", "example.org"),
+        ("UPPERCASE.org", "uppercase.org"),
+        ("SPIFFE://Example.Org/workload", "example.org"),
+        ("SpIfFe://ExAmPlE.oRg", "example.org"),
     ],
 )
 def test_valid_trust_domain(input: str, expected: str) -> None:
@@ -66,10 +70,6 @@ def test_valid_trust_domain(input: str, expected: str) -> None:
             "example$org",
             "Invalid trust domain 'example$org': contains disallowed characters",
         ),
-        (
-            "UPPERCASE.org",
-            "Invalid trust domain 'UPPERCASE.org': contains disallowed characters",
-        ),
     ],
 )
 def test_invalid_trust_domain(input: str, expected_error: str) -> None:
@@ -107,3 +107,21 @@ def test_trust_domain_as_spiffe_id() -> None:
 def test_trust_domain_string_representation() -> None:
     td = TrustDomain("example.org")
     assert str(td) == "example.org"
+
+
+def test_trust_domain_canonical_lowercase_regression() -> None:
+    """Mixed-case labels normalize to lowercase; equality uses canonical name."""
+    a = TrustDomain("ExAmPlE.oRg")
+    b = TrustDomain("example.org")
+    assert str(a) == "example.org"
+    assert a == b
+    assert a == "example.org"
+    assert hash(a) == hash(b)
+
+
+def test_trust_domain_mixed_case_invalid_still_rejected() -> None:
+    """Normalization does not fix structural trust-domain errors."""
+    with pytest.raises(TrustDomainError):
+        TrustDomain("Example..Org")
+    with pytest.raises(TrustDomainError):
+        TrustDomain("SPIFFE://Example..Org/path")

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "idna", specifier = ">=3,<4" },
-    { name = "pyopenssl", specifier = ">=24,<26" },
+    { name = "pyopenssl", specifier = ">=24,<27" },
     { name = "spiffe", editable = "spiffe" },
 ]
 


### PR DESCRIPTION
## What
Make SPIFFE ID URI scheme matching case-insensitive.
Accept mixed-case trust domains, normalize them to lowercase, then validate.
Preserve the path exactly as provided (case-sensitive) and keep existing invalid-path and invalid-trust-domain rejections.

## Why
Align parsing behavior with the SPIFFE ID spec and allow valid mixed-case inputs while keeping a canonical internal trust-domain representation.

## How tested

Updated/added unit tests for scheme/trust-domain mixed-case acceptance, lowercase canonicalization, path case preservation, and continued rejection of invalid trust-domain characters.