### PR TITLE
fix(spiffe_id): accept SPIFFE charset trust domains

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -7,6 +7,7 @@
 - In `X509Svid.parse()`, `X509Svid.parse_raw()`, and `X509Svid.load()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both the leaf SPIFFE ID and private key are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.
 - Accept mixed-case SPIFFE URI scheme and trust domain input during `SpiffeId`/`TrustDomain` parsing, while canonicalizing trust domains to lowercase output.
 - Allow underscore (`_`) in trust-domain labels (for example `trust_domain_1.example.org`) to align trust-domain validation with SPIFFE ID spec section 2.1.
+- Relax trust-domain validation to follow SPIFFE trust-domain character-set rules (`[a-z0-9._-]`), including non-DNS-shaped names such as `example..org`, `.example.org`, `example.org.`, `-example.org`, and `example-.org`.
 
 ## [0.2.6] – 2026-03-15
 

--- a/spiffe/src/spiffe/spiffe_id/spiffe_id.py
+++ b/spiffe/src/spiffe/spiffe_id/spiffe_id.py
@@ -219,16 +219,8 @@ def extract_and_validate_trust_domain(id_or_name: str) -> str:
     if not trust_domain:
         raise TrustDomainError("cannot be empty")
 
-    if trust_domain[0] in ['-', '.'] or trust_domain[-1] in ['-', '.']:
-        raise TrustDomainError("cannot start or end with '-' or '.'", id_or_name)
-
-    if '..' in trust_domain:
-        raise TrustDomainError("cannot contain consecutive dots", id_or_name)
-
-    if not re.match(
-        r'^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-_]*[a-z0-9])?)*$',
-        trust_domain,
-    ):
+    # Validate against the SPIFFE trust-domain character set.
+    if not re.match(r"^[a-z0-9._-]+$", trust_domain):
         raise TrustDomainError("contains disallowed characters", id_or_name)
 
     return trust_domain

--- a/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
+++ b/spiffe/tests/unit/spiffe_id/test_spiffe_id.py
@@ -26,6 +26,18 @@ from spiffe.spiffe_id.spiffe_id import SpiffeId, SpiffeIdError
         "spiffe://example.org/path/to/service",
         "spiffe://example.org/another/path",
         "spiffe://domain.test/a/b/c/d/e/f/g",
+        "spiffe://1.2.3.4/service",
+        "spiffe://a",
+        "spiffe://a_b.example/foo",
+        "spiffe://example.org/foo-bar",
+        "spiffe://example.org/foo_bar",
+        "spiffe://example.org/foo.bar",
+        "spiffe://example.com/9eebccd2-12bf-40a6-b262-65fe0487d453",
+        "spiffe://example..org/path",
+        "spiffe://.example.org/path",
+        "spiffe://example.org./path",
+        "spiffe://-example.org/path",
+        "spiffe://example-.org/path",
     ],
 )
 def test_spiffe_id_valid(id_str: str) -> None:
@@ -62,12 +74,76 @@ def test_spiffe_id_valid(id_str: str) -> None:
             "Invalid SPIFFE ID 'spiffe://example.org/service/': path cannot contain empty segments",
         ),
         (
-            "spiffe://example..org/path",
-            "Invalid SPIFFE ID 'spiffe://example..org/path': Invalid trust domain 'example..org': cannot contain consecutive dots",
+            "spiffe://user@example.org/service",
+            "Invalid SPIFFE ID 'spiffe://user@example.org/service': Invalid trust domain 'user@example.org': contains disallowed characters",
         ),
         (
-            "spiffe://example-.org",
-            "Invalid SPIFFE ID 'spiffe://example-.org': Invalid trust domain 'example-.org': contains disallowed characters",
+            "spiffe://user:pass@example.org/service",
+            "Invalid SPIFFE ID 'spiffe://user:pass@example.org/service': Invalid trust domain 'user:pass@example.org': contains disallowed characters",
+        ),
+        (
+            "spiffe://example.org:8080/service",
+            "Invalid SPIFFE ID 'spiffe://example.org:8080/service': Invalid trust domain 'example.org:8080': contains disallowed characters",
+        ),
+        (
+            "spiffe://1.2.3.4:8443/service",
+            "Invalid SPIFFE ID 'spiffe://1.2.3.4:8443/service': Invalid trust domain '1.2.3.4:8443': contains disallowed characters",
+        ),
+        (
+            "spiffe://[::1]/service",
+            "Invalid SPIFFE ID 'spiffe://[::1]/service': Invalid trust domain '[::1]': contains disallowed characters",
+        ),
+        (
+            "spiffe://[2001:db8::1]/service",
+            "Invalid SPIFFE ID 'spiffe://[2001:db8::1]/service': Invalid trust domain '[2001:db8::1]': contains disallowed characters",
+        ),
+        (
+            "spiffe://example%2eorg/service",
+            "Invalid SPIFFE ID 'spiffe://example%2eorg/service': Invalid trust domain 'example%2eorg': contains disallowed characters",
+        ),
+        (
+            "spiffe://example.org/foo%2Fbar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo%2Fbar': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/%61pi",
+            "Invalid SPIFFE ID 'spiffe://example.org/%61pi': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/service?x=1",
+            "Invalid SPIFFE ID 'spiffe://example.org/service?x=1': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/service#frag",
+            "Invalid SPIFFE ID 'spiffe://example.org/service#frag': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/foo/./bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo/./bar': path segments '.' and '..' are not allowed",
+        ),
+        (
+            "spiffe://example.org/foo/../bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo/../bar': path segments '.' and '..' are not allowed",
+        ),
+        (
+            "spiffe://example.org/foo//bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo//bar': path cannot contain empty segments",
+        ),
+        (
+            "spiffe://example.org/foo;bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo;bar': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/foo:bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo:bar': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/foo@bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo@bar': invalid character in path segment",
+        ),
+        (
+            "spiffe://example.org/foo bar",
+            "Invalid SPIFFE ID 'spiffe://example.org/foo bar': invalid character in path segment",
         ),
     ],
 )
@@ -94,7 +170,7 @@ def test_spiffe_id_equality() -> None:
     id1 = SpiffeId("spiffe://example.org/path")
     id2 = SpiffeId("spiffe://example.org/path")
     assert id1 == id2
-    # assert id1 == "spiffe://example.org/path"
+    assert id1 == "spiffe://example.org/path"
 
 
 def test_spiffe_id_inequality() -> None:
@@ -151,6 +227,8 @@ def test_spiffe_id_path_case_preserved() -> None:
 
 def test_spiffe_id_equivalent_inputs_equal() -> None:
     assert SpiffeId("spiffe://example.org/p") == SpiffeId("SPIFFE://EXAMPLE.ORG/p")
+    assert SpiffeId("SPIFFE://EXAMPLE.ORG/p") == "spiffe://example.org/p"
+    assert SpiffeId("SPIFFE://EXAMPLE.ORG/p") != "SPIFFE://EXAMPLE.ORG/p"
     assert SpiffeId("spiffe://example.org/Service") != SpiffeId("spiffe://example.org/service")
 
 

--- a/spiffe/tests/unit/spiffe_id/test_trust_domain.py
+++ b/spiffe/tests/unit/spiffe_id/test_trust_domain.py
@@ -24,8 +24,21 @@ from spiffe.spiffe_id.spiffe_id import TrustDomain, TrustDomainError
     [
         ("example.org", "example.org"),
         ("trust_domain_1.example.org", "trust_domain_1.example.org"),
+        ("_dmarc.example.org", "_dmarc.example.org"),
+        ("example_.org", "example_.org"),
+        ("1.2.3.4", "1.2.3.4"),
+        ("example..org", "example..org"),
+        (".example.org", ".example.org"),
+        ("example.org.", "example.org."),
+        ("-example.org", "-example.org"),
+        ("example-.org", "example-.org"),
         ("spiffe://example.org/service", "example.org"),
         ("spiffe://example.org", "example.org"),
+        ("spiffe://example..org/path", "example..org"),
+        ("spiffe://.example.org/path", ".example.org"),
+        ("spiffe://example.org./path", "example.org."),
+        ("spiffe://-example.org/path", "-example.org"),
+        ("spiffe://example-.org/path", "example-.org"),
         ("domain.test", "domain.test"),
         ("a.b.c.d.e.f", "a.b.c.d.e.f"),
         ("Example.Org", "example.org"),
@@ -48,24 +61,28 @@ def test_valid_trust_domain(input: str, expected: str) -> None:
             "Invalid trust domain 'http://example.org': ID form does not start with 'spiffe://'",
         ),
         (
-            "spiffe://example..org",
-            "Invalid trust domain 'spiffe://example..org': cannot contain consecutive dots",
-        ),
-        (
-            "spiffe://example-.org",
-            "Invalid trust domain 'spiffe://example-.org': contains disallowed characters",
-        ),
-        (
-            "spiffe://-example.org",
-            "Invalid trust domain 'spiffe://-example.org': cannot start or end with '-' or '.'",
-        ),
-        (
             "spiffe://example.org?query",
             "Invalid trust domain 'spiffe://example.org?query': contains disallowed characters",
         ),
         (
             "spiffe://example.org#fragment",
             "Invalid trust domain 'spiffe://example.org#fragment': contains disallowed characters",
+        ),
+        (
+            "user@example.org",
+            "Invalid trust domain 'user@example.org': contains disallowed characters",
+        ),
+        (
+            "example.org:8080",
+            "Invalid trust domain 'example.org:8080': contains disallowed characters",
+        ),
+        (
+            "[::1]",
+            "Invalid trust domain '[::1]': contains disallowed characters",
+        ),
+        (
+            "example%2eorg",
+            "Invalid trust domain 'example%2eorg': contains disallowed characters",
         ),
         (
             "example$org",
@@ -124,6 +141,6 @@ def test_trust_domain_canonical_lowercase_regression() -> None:
 def test_trust_domain_mixed_case_invalid_still_rejected() -> None:
     """Normalization does not fix structural trust-domain errors."""
     with pytest.raises(TrustDomainError):
-        TrustDomain("Example..Org")
+        TrustDomain("Example$.Org")
     with pytest.raises(TrustDomainError):
-        TrustDomain("SPIFFE://Example..Org/path")
+        TrustDomain("SPIFFE://Example$.Org/path")


### PR DESCRIPTION
## What
- Relaxed trust-domain validation to accept names matching SPIFFE trust-domain charset ([a-z0-9._-]), including non-DNS-shaped forms.
- Updated trust-domain and SPIFFE ID tests to treat those trust domains as valid and to keep userinfo/port/IPv6/percent-encoding and path edge cases covered.

## Why
- Align trust-domain parsing behavior with the SPIFFE ID spec character-set requirements.
- Preserve strict rejection of clearly invalid authority/path forms while improving coverage for parser edge cases.

## How tested

Unit tests