### PR TITLE
fix(deps): align grpcio floor with workload_pb2_grpc codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__
 */dist/*
 */_build/*
 */build/*
+# setuptools output (*/build/* only matches one path segment under build/)
+**/build/
+**/dist/
 reports/*
 .coverage
 .tox/

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Raised the minimum `grpcio` requirement to match the version implied by the checked-in `workload_pb2_grpc.py` generated code, so dependency pins cannot resolve to a runtime that fails on import.
+
 ### Changed
 - Tightened `X509Svid` leaf SPIFFE ID validation to reject trust-domain root IDs in leaf certificates (a non-empty path is required).
 - In `X509Svid.parse()`, `X509Svid.parse_raw()`, and `X509Svid.load()`, leaf certificate SPIFFE ID validation now occurs before private key parsing; when both the leaf SPIFFE ID and private key are invalid, `InvalidLeafCertificateError` now takes precedence over `ParsePrivateKeyError`.

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [{ name = "Max Lambrecht", email = "maxlambrecht@gmail.com" }]
 dependencies = [
-  "grpcio>=1.62,<2",
+  "grpcio>=1.78.0,<2",
   "cryptography>=45,<47",
   "pyjwt[crypto]>=2,<2.13",
   "pyasn1>=0.6.0,<0.7.0",
@@ -21,7 +21,7 @@ Repository = "https://github.com/HewlettPackard/py-spiffe"
 
 [dependency-groups]
 dev = [
-  "grpcio-tools>=1.76.0,<2",
+  "grpcio-tools>=1.78.0,<2",
   "mypy-protobuf>=5,<6",
   "coverage>=7,<8",
   "testutils",
@@ -59,7 +59,8 @@ module = ["spiffe._proto.workload_pb2_grpc"]
 ignore_errors = true
 
 [tool.pyright]
-exclude = ["src/spiffe/_proto"]
+# setuptools / local installs copy sources under build/; do not type-check those trees
+exclude = ["src/spiffe/_proto", "build", "dist"]
 ignore = ["src/spiffe/_proto/workload_pb2_grpc.py"]
 typeCheckingMode = "standard"
 

--- a/tasks.py
+++ b/tasks.py
@@ -149,7 +149,9 @@ def lint(args: argparse.Namespace) -> None:
         )
         run_uv_package(package, "ruff", "check", *package.lint_targets)
         run_uv_package(package, "--all-groups", "mypy")
-        run_uv_package(package, "--all-groups", "pyright")
+        # Pass src/tests explicitly so pyright does not type-check setuptools output
+        # under build/ when no paths are given (it would otherwise assume the package root).
+        run_uv_package(package, "--all-groups", "pyright", *package.lint_targets)
         if package.verifytypes_module is not None:
             run_uv_package(
                 package,

--- a/uv.lock
+++ b/uv.lock
@@ -1011,7 +1011,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=45,<47" },
-    { name = "grpcio", specifier = ">=1.62,<2" },
+    { name = "grpcio", specifier = ">=1.78.0,<2" },
     { name = "pem", specifier = ">=23,<24" },
     { name = "protobuf", specifier = ">=6.31.1,<8" },
     { name = "pyasn1", specifier = ">=0.6.0,<0.7.0" },
@@ -1022,7 +1022,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7,<8" },
-    { name = "grpcio-tools", specifier = ">=1.76.0,<2" },
+    { name = "grpcio-tools", specifier = ">=1.78.0,<2" },
     { name = "mypy-protobuf", specifier = ">=5,<6" },
     { name = "testutils", editable = "testutils" },
     { name = "types-grpcio", specifier = ">=1.0,<2" },


### PR DESCRIPTION
## What

Raise the minimum grpcio (and dev grpcio-tools) so they match GRPC_GENERATED_VERSION in checked-in workload_pb2_grpc.py.
Refresh uv.lock and note the change in spiffe/CHANGELOG.md.

## Why

The generated gRPC module already fails at import when the runtime is too old; the previous lower bound allowed pins that satisfied metadata but broke at runtime (same idea as the protobuf floor in 0.2.5).

Fixes #416 

