### PR TITLE
chore(release): bump spiffe to 0.2.7

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.7] – 2026-04-18
 
 ### Fixed
 - Raised the minimum `grpcio` requirement to match the version implied by the checked-in `workload_pb2_grpc.py` generated code, so dependency pins cannot resolve to a runtime that fails on import.

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary 
Ship spiffe 0.2.7: set version in spiffe/pyproject.toml, finalize spiffe/CHANGELOG.md (move prior unreleased notes under [0.2.7] with release date), and refresh uv.lock for the workspace spiffe package.