### PR TITLE
chore(deps): remove cryptography upper bound

### DIFF
--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 authors = [{ name = "Max Lambrecht", email = "maxlambrecht@gmail.com" }]
 dependencies = [
   "grpcio>=1.78.0,<2",
-  "cryptography>=46,<48",
+  "cryptography>=46",
   "pyjwt[crypto]>=2,<2.13",
   "pyasn1>=0.6.0,<0.7.0",
   "pyasn1-modules>=0.4.0,<0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1060,7 +1060,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=46,<47" },
+    { name = "cryptography", specifier = ">=46" },
     { name = "grpcio", specifier = ">=1.78.0,<2" },
     { name = "pem", specifier = ">=23,<24" },
     { name = "protobuf", specifier = ">=6.31.1,<8" },


### PR DESCRIPTION
**Affected functionality**

Runtime dependency constraints for the `spiffe` package.

**Description of change**

Removes the upper bound on the `cryptography` runtime dependency:

- changes `cryptography>=46,<48` to `cryptography>=46`
- refreshes `uv.lock` metadata

As a library, `spiffe` should avoid blocking downstream applications from upgrading `cryptography` unless there is a known incompatibility. CI and Dependabot can catch future breakage, and a targeted upper bound can be reintroduced if needed.