### PR TITLE
chore(release): bump spiffe to 0.2.8

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.8] – 2026-05-08
+
+### Changed
+- Removed the upper bound on the `cryptography` dependency while keeping the `>=46` floor, allowing compatible future `cryptography` releases to resolve without requiring a package update.
+
 ## [0.2.7] – 2026-04-18
 
 ### Fixed

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.2.7"
+version = "0.2.8"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Release metadata for the `spiffe` package.

**Description of change**
Bumps `spiffe` to 0.2.8 and updates the changelog and lockfile. This release documents the removal of the upper bound on the `cryptography` dependency while preserving the `>=46` floor.

Tested with:

- `./dev build spiffe`

**Which issue this PR fixes**
N/A