### PR TITLE
fix(tls): parse SPIFFE URI SANs safely

### DIFF
--- a/spiffe-tls/src/spiffetls/tlsconfig/authorize.py
+++ b/spiffe-tls/src/spiffetls/tlsconfig/authorize.py
@@ -18,8 +18,10 @@ import logging
 from typing import Callable, Set
 
 from OpenSSL import crypto
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
 
-from spiffe.spiffe_id.spiffe_id import SpiffeId, TrustDomain
+from spiffe.spiffe_id.spiffe_id import SpiffeId, SpiffeIdError, TrustDomain
 from spiffe.spiffe_id.spiffe_id import SCHEME_PREFIX
 from spiffe.utils.errors import X509CertificateError
 
@@ -93,22 +95,41 @@ def authorize_member_of(
 
 def _spiffe_id_from_cert(cert: crypto.X509) -> SpiffeId:
     """Returns the SPIFFE ID from a pyOpenSSL certificate"""
-    for i in range(cert.get_extension_count()):
-        ext = cert.get_extension(i)
-        if "subjectAltName" in str(ext.get_short_name()):
-            sans = str(ext)
-            uris = [
-                uri.replace('URI:', '').strip() for uri in sans.split(',') if 'URI:' in uri
-            ]
-            spiffe_ids = [uri for uri in uris if uri.startswith(SCHEME_PREFIX)]
+    cryptography_cert = cert.to_cryptography()
 
-            if spiffe_ids:
-                return SpiffeId(spiffe_ids[0])
-            else:
-                raise X509CertificateError(
-                    'Certificate does not contain a SPIFFE ID in the URI SAN'
-                )
+    try:
+        ext = cryptography_cert.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+    except x509.ExtensionNotFound as e:
+        raise X509CertificateError(
+            'Certificate does not contain a Subject Alternative Name extension'
+        ) from e
 
-    raise X509CertificateError(
-        'Certificate does not contain a Subject Alternative Name extension'
-    )
+    san_value = ext.value
+    if not isinstance(san_value, x509.SubjectAlternativeName):
+        raise X509CertificateError(
+            'Certificate does not contain a valid Subject Alternative Name extension'
+        )
+
+    uri_sans = san_value.get_values_for_type(x509.UniformResourceIdentifier)
+    if len(uri_sans) == 0:
+        raise X509CertificateError(
+            'Certificate does not contain a URI SAN (expected exactly one SPIFFE ID)'
+        )
+
+    if len(uri_sans) != 1:
+        raise X509CertificateError(
+            'Certificate contains multiple URI SAN entries (expected exactly one SPIFFE ID)'
+        )
+
+    uri = uri_sans[0]
+    if not uri.startswith(SCHEME_PREFIX):
+        raise X509CertificateError('Certificate URI SAN is not a SPIFFE ID')
+
+    try:
+        return SpiffeId(uri)
+    except SpiffeIdError as e:
+        raise X509CertificateError(
+            f'Certificate contains a malformed SPIFFE ID in the URI SAN: {uri!r}'
+        ) from e

--- a/spiffe-tls/tests/unit/test_authorize.py
+++ b/spiffe-tls/tests/unit/test_authorize.py
@@ -1,0 +1,118 @@
+"""
+(C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+"""
+
+import datetime
+from typing import List
+
+from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509 import Certificate
+from cryptography.x509.oid import NameOID
+
+from spiffe.spiffe_id.spiffe_id import SpiffeId, TrustDomain
+from spiffetls.tlsconfig.authorize import (
+    authorize_any,
+    authorize_id,
+    authorize_member_of,
+)
+
+
+def test_authorize_any_with_one_spiffe_uri_san_succeeds() -> None:
+    cert = _make_cert(uri_sans=["spiffe://example.org/service"], dns_sans=[])
+
+    assert authorize_any()(cert)
+
+
+def test_authorize_any_with_spiffe_uri_san_and_dns_san_succeeds() -> None:
+    cert = _make_cert(
+        uri_sans=["spiffe://example.org/service"],
+        dns_sans=["service.example.org"],
+    )
+
+    assert authorize_any()(cert)
+
+
+def test_authorize_any_with_zero_uri_sans_fails() -> None:
+    cert = _make_cert(uri_sans=[], dns_sans=["service.example.org"])
+
+    assert not authorize_any()(cert)
+
+
+def test_authorize_any_with_multiple_uri_sans_fails() -> None:
+    cert = _make_cert(
+        uri_sans=["spiffe://example.org/service", "https://example.org/service"],
+        dns_sans=[],
+    )
+
+    assert not authorize_any()(cert)
+
+
+def test_authorize_any_with_non_spiffe_uri_san_fails() -> None:
+    cert = _make_cert(uri_sans=["https://example.org/service"], dns_sans=[])
+
+    assert not authorize_any()(cert)
+
+
+def test_authorize_id_and_member_of_use_parsed_spiffe_uri_san() -> None:
+    cert = _make_cert(
+        uri_sans=["spiffe://example.org/service"],
+        dns_sans=["service.example.org"],
+    )
+
+    assert authorize_id(SpiffeId("spiffe://example.org/service"))(cert)
+    assert authorize_member_of(TrustDomain("example.org"))(cert)
+
+
+def test_authorize_id_and_member_of_reject_multiple_uri_sans() -> None:
+    cert = _make_cert(
+        uri_sans=["spiffe://example.org/service", "https://example.org/service"],
+        dns_sans=[],
+    )
+
+    assert not authorize_id(SpiffeId("spiffe://example.org/service"))(cert)
+    assert not authorize_member_of(TrustDomain("example.org"))(cert)
+
+
+def _make_cert(*, uri_sans: List[str], dns_sans: List[str]) -> crypto.X509:
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "test"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "leaf"),
+        ]
+    )
+
+    san_entries: List[x509.GeneralName] = []
+    san_entries.extend(x509.UniformResourceIdentifier(uri) for uri in uri_sans)
+    san_entries.extend(x509.DNSName(dns) for dns in dns_sans)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert: Certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(x509.SubjectAlternativeName(san_entries), critical=False)
+        .sign(private_key=key, algorithm=hashes.SHA256())
+    )
+
+    return crypto.X509.from_cryptography(cert)


### PR DESCRIPTION
## What

Update `spiffe-tls` certificate authorization to parse URI SANs through `pyOpenSSL` `to_cryptography()` and `cryptography.x509.SubjectAlternativeName` instead of text parsing.

The authorizer now rejects certificates with zero URI SANs, multiple URI SANs, or a non-SPIFFE URI SAN, while still allowing DNS SANs alongside exactly one SPIFFE URI SAN.

## Why

Text-based SAN parsing can accept malformed or profile-invalid certificates. This aligns TLS authorization with the X.509-SVID profile and existing `X509Svid.parse` behavior.

## How tested

- `uv run --package spiffe-tls pytest spiffe-tls/tests/unit/test_authorize.py`
- `uv run --package spiffe-tls pytest spiffe-tls/tests/unit`
- `uv run ruff check spiffe-tls/src/spiffetls/tlsconfig/authorize.py spiffe-tls/tests/unit/test_authorize.py`
- `uv run pyright --project spiffe-tls/pyproject.toml spiffe-tls/tests/unit/test_authorize.py`