### PR TITLE
fix(x509): create private key files with restrictive permissions

### DIFF
--- a/spiffe/src/spiffe/utils/certificate_utils.py
+++ b/spiffe/src/spiffe/utils/certificate_utils.py
@@ -221,9 +221,20 @@ def write_private_key_to_file(
     try:
         private_key_bytes = _extract_private_key_bytes(encoding, private_key)
 
-        with open(private_key_path, 'wb') as private_key_file:
-            os.chmod(private_key_file.name, _PRIVATE_KEY_FILE_MODE)
-            private_key_file.write(private_key_bytes)
+        fd = -1
+        try:
+            fd = os.open(
+                private_key_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                _PRIVATE_KEY_FILE_MODE,
+            )
+            os.fchmod(fd, _PRIVATE_KEY_FILE_MODE)
+            with os.fdopen(fd, 'wb') as private_key_file:
+                fd = -1
+                private_key_file.write(private_key_bytes)
+        finally:
+            if fd != -1:
+                os.close(fd)
     except Exception as err:
         raise StorePrivateKeyError(str(err)) from err
 

--- a/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
+++ b/spiffe/tests/unit/svid/x509svid/test_x509_svid.py
@@ -19,6 +19,7 @@ from typing import List
 
 import datetime
 import os
+import stat
 
 import pytest
 from pytest_mock import MockerFixture
@@ -516,6 +517,44 @@ def test_save_chain_and_ec_key_as_pem(tmpdir: str, clean_files: List[str]) -> No
     assert isinstance(x509_svid.cert_chain[1], Certificate)
     assert isinstance(saved_svid.private_key, ec.EllipticCurvePrivateKey)
     assert _extract_spiffe_id(saved_svid.leaf) == expected_spiffe_id
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file mode assertion")
+def test_save_private_key_file_mode_is_restrictive(
+    tmpdir: str, clean_files: List[str]
+) -> None:
+    chain_bytes = read_bytes('2-chain.pem')
+    key_bytes = read_bytes('2-key.pem')
+    x509_svid = X509Svid.parse(chain_bytes, key_bytes)
+
+    chain_file = tmpdir.join('chain.pem')
+    key_file = tmpdir.join('key.pem')
+    clean_files.extend([chain_file, key_file])
+
+    x509_svid.save(chain_file, key_file, serialization.Encoding.PEM)
+
+    assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file mode assertion")
+def test_save_private_key_file_mode_is_restrictive_when_file_exists(
+    tmpdir: str, clean_files: List[str]
+) -> None:
+    chain_bytes = read_bytes('2-chain.pem')
+    key_bytes = read_bytes('2-key.pem')
+    x509_svid = X509Svid.parse(chain_bytes, key_bytes)
+
+    chain_file = tmpdir.join('chain.pem')
+    key_file = tmpdir.join('key.pem')
+    clean_files.extend([chain_file, key_file])
+
+    with open(key_file, "wb") as f:
+        f.write(b"existing key")
+    os.chmod(key_file, 0o644)
+
+    x509_svid.save(chain_file, key_file, serialization.Encoding.PEM)
+
+    assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600
 
 
 def test_save_chain_and_rsa_key_as_der(tmpdir: str, clean_files: List[str]) -> None:


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Private key persistence for X.509-SVID save operations.

**Description of change**

Update private key saving to create/truncate key files with mode `0o600` from the initial `os.open` call, then apply `os.fchmod(..., 0o600)` before writing as an additional safeguard.

This removes the permission window caused by creating private key files with `open(..., "wb")` before applying restrictive permissions. Certificate-chain writing is unchanged.

Added POSIX regression coverage confirming saved private key files end with mode `0o600`, including when overwriting an existing file with broader permissions.

Tested with:

- `uv run --package spiffe pytest spiffe/tests/unit/svid/x509svid/test_x509_svid.py`
- `uv run ruff check spiffe/src/spiffe/utils/certificate_utils.py spiffe/tests/unit/svid/x509svid/test_x509_svid.py`
- `uv run pyright --project spiffe/pyproject.toml spiffe/src/spiffe/utils/certificate_utils.py spiffe/tests/unit/svid/x509svid/test_x509_svid.py`

**Which issue this PR fixes**

N/A