### PR TITLE
fix(workloadapi): close owned client on source init failure and stream errros

### DIFF
--- a/spiffe/src/spiffe/workloadapi/jwt_source.py
+++ b/spiffe/src/spiffe/workloadapi/jwt_source.py
@@ -84,10 +84,12 @@ class JwtSource:
 
         # Track ownership: if we create the client, we own it
         self._owns_client = workload_api_client is None
+        self._owned_client_closed = False
         self._workload_api_client = (
             workload_api_client if workload_api_client else WorkloadApiClient(socket_path)
         )
         self._client_cancel_handler: Optional[StreamCancelHandler] = None
+        self._stream_cancelled = False
 
         # Start the watcher in a separate thread
         threading.Thread(target=self._start_watcher, daemon=True).start()
@@ -96,13 +98,13 @@ class JwtSource:
         initialized = self._initialization_event.wait(timeout=timeout_in_seconds)
 
         if not initialized:
-            self._closed = True
+            self.close()
             raise JwtSourceError(
                 "Failed to initialize JwtSource: Timeout waiting for the first update."
             )
 
         if self._error is not None:
-            self._closed = True
+            self.close()
             raise JwtSourceError(f"Failed to create JwtSource: {self._error}") from self._error
 
     @property
@@ -175,25 +177,55 @@ class JwtSource:
         """
         _logger.info("Closing JWT Source")
         with self._lock:
-            if self._closed:
+            self._closed = True
+
+        self._cancel_stream()
+        self._close_owned_client()
+
+    def _cancel_stream(self) -> None:
+        cancel_handler: Optional[StreamCancelHandler]
+        with self._lock:
+            if self._stream_cancelled:
                 return
+            self._stream_cancelled = True
+            cancel_handler = self._client_cancel_handler
+
+        try:
+            if cancel_handler:
+                cancel_handler.cancel()
+        except Exception as err:
+            _logger.exception(
+                'JWT Source: Exception canceling the Workload API client connection: {}'.format(
+                    str(err)
+                )
+            )
+
+    def _close_owned_client(self) -> None:
+        with self._lock:
+            if not self._owns_client or self._owned_client_closed:
+                return
+            self._owned_client_closed = True
+
+        try:
+            self._workload_api_client.close()
+        except Exception as err:
+            _logger.exception(
+                'Exception closing owned Workload API client: {}'.format(str(err))
+            )
+
+    def _set_client_cancel_handler(self, cancel_handler: StreamCancelHandler) -> None:
+        with self._lock:
+            self._client_cancel_handler = cancel_handler
+            should_cancel = self._closed or self._stream_cancelled
+
+        if should_cancel:
             try:
-                if self._client_cancel_handler:
-                    self._client_cancel_handler.cancel()
+                cancel_handler.cancel()
             except Exception as err:
                 _logger.exception(
                     'JWT Source: Exception canceling the Workload API client connection: {}'.format(
                         str(err)
                     )
-                )
-            self._closed = True
-
-        if self._owns_client:
-            try:
-                self._workload_api_client.close()
-            except Exception as err:
-                _logger.exception(
-                    'Exception closing owned Workload API client: {}'.format(str(err))
                 )
 
     def is_closed(self) -> bool:
@@ -225,9 +257,10 @@ class JwtSource:
                 pass
 
     def _start_watcher(self) -> None:
-        self._client_cancel_handler = self._workload_api_client.stream_jwt_bundles(
+        cancel_handler = self._workload_api_client.stream_jwt_bundles(
             self._set_jwt_bundle_set, self._on_error
         )
+        self._set_client_cancel_handler(cancel_handler)
 
     def _set_jwt_bundle_set(self, jwt_bundle_set: JwtBundleSet) -> None:
         _logger.debug('JWT Source: setting new bundle update')
@@ -252,11 +285,8 @@ class JwtSource:
         with self._lock:
             self._error = error
             self._closed = True
-            try:
-                if self._client_cancel_handler:
-                    self._client_cancel_handler.cancel()
-            except Exception as err:
-                _logger.exception(f"Exception canceling stream on error: {err}")
+        self._cancel_stream()
+        self._close_owned_client()
         self._initialization_event.set()
 
     @staticmethod

--- a/spiffe/src/spiffe/workloadapi/x509_source.py
+++ b/spiffe/src/spiffe/workloadapi/x509_source.py
@@ -88,9 +88,11 @@ class X509Source:
 
         # Track ownership: if we create the client, we own it
         self._owns_client = workload_api_client is None
+        self._owned_client_closed = False
         self._workload_api_client = workload_api_client or WorkloadApiClient(socket_path)
         self._picker = svid_picker
         self._client_cancel_handler: Optional[StreamCancelHandler] = None
+        self._stream_cancelled = False
 
         # Start the watcher in a separate thread
         threading.Thread(target=self._start_watcher, daemon=True).start()
@@ -99,13 +101,13 @@ class X509Source:
         initialized = self._initialization_event.wait(timeout=timeout_in_seconds)
 
         if not initialized:
-            self._closed = True
+            self.close()
             raise X509SourceError(
                 "Failed to initialize X509Source: Timeout waiting for the first update."
             )
 
         if self._error is not None:
-            self._closed = True
+            self.close()
             raise X509SourceError(
                 f"Failed to create X509Source: {self._error}"
             ) from self._error
@@ -186,25 +188,53 @@ class X509Source:
         """
         _logger.info("Closing X.509 Source")
         with self._lock:
-            if self._closed:
+            self._closed = True
+
+        self._cancel_stream()
+        self._close_owned_client()
+
+    def _cancel_stream(self) -> None:
+        cancel_handler: Optional[StreamCancelHandler]
+        with self._lock:
+            if self._stream_cancelled:
                 return
+            self._stream_cancelled = True
+            cancel_handler = self._client_cancel_handler
+
+        try:
+            if cancel_handler:
+                cancel_handler.cancel()
+        except Exception as err:
+            _logger.exception(
+                'Exception canceling the Workload API client connection: {}'.format(str(err))
+            )
+
+    def _close_owned_client(self) -> None:
+        with self._lock:
+            if not self._owns_client or self._owned_client_closed:
+                return
+            self._owned_client_closed = True
+
+        try:
+            self._workload_api_client.close()
+        except Exception as err:
+            _logger.exception(
+                'Exception closing owned Workload API client: {}'.format(str(err))
+            )
+
+    def _set_client_cancel_handler(self, cancel_handler: StreamCancelHandler) -> None:
+        with self._lock:
+            self._client_cancel_handler = cancel_handler
+            should_cancel = self._closed or self._stream_cancelled
+
+        if should_cancel:
             try:
-                if self._client_cancel_handler:
-                    self._client_cancel_handler.cancel()
+                cancel_handler.cancel()
             except Exception as err:
                 _logger.exception(
                     'Exception canceling the Workload API client connection: {}'.format(
                         str(err)
                     )
-                )
-            self._closed = True
-
-        if self._owns_client:
-            try:
-                self._workload_api_client.close()
-            except Exception as err:
-                _logger.exception(
-                    'Exception closing owned Workload API client: {}'.format(str(err))
                 )
 
     def is_closed(self) -> bool:
@@ -236,9 +266,10 @@ class X509Source:
                 pass
 
     def _start_watcher(self) -> None:
-        self._client_cancel_handler = self._workload_api_client.stream_x509_contexts(
+        cancel_handler = self._workload_api_client.stream_x509_contexts(
             self._set_context, self._on_error
         )
+        self._set_client_cancel_handler(cancel_handler)
 
     def _set_context(self, x509_context: X509Context) -> None:
         try:
@@ -277,11 +308,8 @@ class X509Source:
         with self._lock:
             self._error = error
             self._closed = True
-            try:
-                if self._client_cancel_handler:
-                    self._client_cancel_handler.cancel()
-            except Exception as err:
-                _logger.exception(f"Exception canceling stream on error: {err}")
+        self._cancel_stream()
+        self._close_owned_client()
         self._initialization_event.set()
 
     @staticmethod

--- a/spiffe/tests/unit/workloadapi/test_jwt_source.py
+++ b/spiffe/tests/unit/workloadapi/test_jwt_source.py
@@ -14,8 +14,11 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
+import threading
+import time
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +40,48 @@ from testutils.jwt import (
 )
 
 SPIFFE_ID = SpiffeId('spiffe://domain.test/my_service')
+
+
+class _FakeCancelHandler:
+    def __init__(self) -> None:
+        self.cancelled = threading.Event()
+        self.cancel_count = 0
+
+    def cancel(self) -> None:
+        self.cancel_count += 1
+        self.cancelled.set()
+
+
+class _FakeJwtClient:
+    def __init__(
+        self,
+        cancel_handler: _FakeCancelHandler,
+        *,
+        stream_delay: float = 0,
+        stream_error: Exception | None = None,
+        jwt_bundle_set: JwtBundleSet | None = None,
+    ) -> None:
+        self.cancel_handler = cancel_handler
+        self.stream_delay = stream_delay
+        self.stream_error = stream_error
+        self.jwt_bundle_set = jwt_bundle_set
+        self.close_count = 0
+
+    def stream_jwt_bundles(
+        self,
+        on_success: Callable[[JwtBundleSet], None],
+        on_error: Callable[[Exception], None],
+    ) -> _FakeCancelHandler:
+        if self.stream_delay:
+            time.sleep(self.stream_delay)
+        if self.stream_error:
+            on_error(self.stream_error)
+        if self.jwt_bundle_set:
+            on_success(self.jwt_bundle_set)
+        return self.cancel_handler
+
+    def close(self) -> None:
+        self.close_count += 1
 
 
 @pytest.fixture
@@ -74,6 +119,59 @@ def mock_client_fetch_jwt_bundles(mocker: MockerFixture, client: WorkloadApiClie
     client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(
         side_effect=lambda *args, **kwargs: response_generator()
     )
+
+
+def make_jwt_bundle_set() -> JwtBundleSet:
+    bundle = JwtBundle.parse(TrustDomain('domain.test'), JWKS_1_EC_KEY)
+    return JwtBundleSet.of([bundle])
+
+
+def test_jwt_source_init_timeout_cancels_stream_and_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeJwtClient(cancel_handler, stream_delay=0.05)
+
+    with patch('spiffe.workloadapi.jwt_source.WorkloadApiClient', return_value=fake_client):
+        with pytest.raises(JwtSourceError):
+            JwtSource(timeout_in_seconds=0.001)
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_jwt_source_init_failure_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeJwtClient(cancel_handler, stream_error=Exception("boom"))
+
+    with patch('spiffe.workloadapi.jwt_source.WorkloadApiClient', return_value=fake_client):
+        with pytest.raises(JwtSourceError):
+            JwtSource(timeout_in_seconds=1)
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_jwt_source_init_timeout_does_not_close_external_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeJwtClient(cancel_handler, stream_delay=0.05)
+
+    with pytest.raises(JwtSourceError):
+        JwtSource(cast(WorkloadApiClient, fake_client), timeout_in_seconds=0.001)
+
+    assert fake_client.close_count == 0
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_jwt_source_on_error_after_init_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeJwtClient(cancel_handler, jwt_bundle_set=make_jwt_bundle_set())
+
+    with patch('spiffe.workloadapi.jwt_source.WorkloadApiClient', return_value=fake_client):
+        jwt_source = JwtSource(timeout_in_seconds=1)
+
+    jwt_source._on_error(WorkloadApiError("Test error"))
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
 
 
 def test_jwt_source_subscription_and_unsubscription_behavior(

--- a/spiffe/tests/unit/workloadapi/test_x509_source.py
+++ b/spiffe/tests/unit/workloadapi/test_x509_source.py
@@ -14,6 +14,10 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
+from collections.abc import Callable
+import threading
+import time
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +35,48 @@ from spiffe.workloadapi.workload_api_client import (
     WorkloadApiClient,
 )
 from testutils.certs import FEDERATED_BUNDLE, CHAIN1, KEY1, BUNDLE, CHAIN2, KEY2
+
+
+class _FakeCancelHandler:
+    def __init__(self) -> None:
+        self.cancelled = threading.Event()
+        self.cancel_count = 0
+
+    def cancel(self) -> None:
+        self.cancel_count += 1
+        self.cancelled.set()
+
+
+class _FakeX509Client:
+    def __init__(
+        self,
+        cancel_handler: _FakeCancelHandler,
+        *,
+        stream_delay: float = 0,
+        stream_error: Exception | None = None,
+        x509_context: X509Context | None = None,
+    ) -> None:
+        self.cancel_handler = cancel_handler
+        self.stream_delay = stream_delay
+        self.stream_error = stream_error
+        self.x509_context = x509_context
+        self.close_count = 0
+
+    def stream_x509_contexts(
+        self,
+        on_success: Callable[[X509Context], None],
+        on_error: Callable[[Exception], None],
+    ) -> _FakeCancelHandler:
+        if self.stream_delay:
+            time.sleep(self.stream_delay)
+        if self.stream_error:
+            on_error(self.stream_error)
+        if self.x509_context:
+            on_success(self.x509_context)
+        return self.cancel_handler
+
+    def close(self) -> None:
+        self.close_count += 1
 
 
 @pytest.fixture
@@ -69,6 +115,13 @@ def mock_client_return_multiple_svids(
             ]
         )
     )
+
+
+def make_x509_context() -> X509Context:
+    svid = X509Svid.parse_raw(CHAIN1, KEY1)
+    bundle = X509Bundle.parse_raw(TrustDomain("example.org"), BUNDLE)
+    bundle_set = X509BundleSet.of([bundle])
+    return X509Context([svid], bundle_set)
 
 
 def test_x509_source_get_default_x509_svid(
@@ -123,6 +176,54 @@ def test_x509_source_get_x509_svid_with_invalid_picker(
         str(err.value)
         == 'X.509 Source error: Failed to create X509Source: Failed to pick X509 SVID: list index out of range'
     )
+
+
+def test_x509_source_init_timeout_cancels_stream_and_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeX509Client(cancel_handler, stream_delay=0.05)
+
+    with patch('spiffe.workloadapi.x509_source.WorkloadApiClient', return_value=fake_client):
+        with pytest.raises(X509SourceError):
+            X509Source(timeout_in_seconds=0.001)
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_x509_source_init_failure_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeX509Client(cancel_handler, stream_error=Exception("boom"))
+
+    with patch('spiffe.workloadapi.x509_source.WorkloadApiClient', return_value=fake_client):
+        with pytest.raises(X509SourceError):
+            X509Source(timeout_in_seconds=1)
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_x509_source_init_timeout_does_not_close_external_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeX509Client(cancel_handler, stream_delay=0.05)
+
+    with pytest.raises(X509SourceError):
+        X509Source(cast(WorkloadApiClient, fake_client), timeout_in_seconds=0.001)
+
+    assert fake_client.close_count == 0
+    assert cancel_handler.cancelled.wait(timeout=1)
+
+
+def test_x509_source_on_error_after_init_closes_owned_client() -> None:
+    cancel_handler = _FakeCancelHandler()
+    fake_client = _FakeX509Client(cancel_handler, x509_context=make_x509_context())
+
+    with patch('spiffe.workloadapi.x509_source.WorkloadApiClient', return_value=fake_client):
+        x509_source = X509Source(timeout_in_seconds=1)
+
+    x509_source._on_error(WorkloadApiError("Test error"))
+
+    assert fake_client.close_count == 1
+    assert cancel_handler.cancelled.wait(timeout=1)
 
 
 def test_x509_source_get_bundle_for_trust_domain(


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Workload API sources: `X509Source` and `JwtSource` initialization, stream lifecycle, and cleanup when the source owns the `WorkloadApiClient`. Callers who pass their own client are unchanged (the source still does not close it).

**Description of change**

When initialization times out or fails before the first successful update, the source now performs proper teardown: cancel the streaming Workload API watch when a cancel handler exists, and close the `WorkloadApiClient` only when the source created it (`_owns_client`). This fixes leaks where `_closed` was set without closing an owned client or cancelling the stream.

If `_on_error` runs after initialization and the source owns the client, the owned client is closed (stream cancellation remains handled). A race where `close()` runs before `_client_cancel_handler` is assigned is addressed by recording pending cancellation and cancelling the handler when it becomes available (`StreamCancelHandler` already supports cancel-before-iterator).

Added unit tests for both sources covering init timeout, init failure, external client not closed, and `_on_error` after init closing an owned client.

Tests run:

- `uv run --group test pytest spiffe/tests/unit/workloadapi/test_x509_source.py spiffe/tests/unit/workloadapi/test_jwt_source.py`
- `uv run --group dev ruff check` on the touched files

**Which issue this PR fixes**

<!-- optional -->

---

**Suggested PR title (Conventional Commits):**  
`fix(workloadapi): close owned client on source init failure and stream errors`

**Suggested branch:**  
`fix/workload-source-init-cleanup`

**Suggested commit:**  
`fix(workloadapi): close owned client on source init failure and stream errors`