### PR TITLE
fix(workloadapi): cancel server-stream RPC after one-shot fetch

### DIFF
--- a/spiffe/src/spiffe/workloadapi/workload_api_client.py
+++ b/spiffe/src/spiffe/workloadapi/workload_api_client.py
@@ -595,9 +595,12 @@ class WorkloadApiClient:
     def _call_fetch_x509_svid(self) -> workload_pb2.X509SVIDResponse:
         response = self._spiffe_workload_api_stub.FetchX509SVID(workload_pb2.X509SVIDRequest())
         try:
-            item = next(response)
-        except StopIteration:
-            raise FetchX509SvidError('X.509 SVID response is invalid')
+            try:
+                item = next(response)
+            except StopIteration:
+                raise FetchX509SvidError('X.509 SVID response is invalid')
+        finally:
+            self._cancel_response_iterator(response)
         if len(item.svids) == 0:
             raise FetchX509SvidError('X.509 SVID response is empty')
         return item
@@ -607,9 +610,12 @@ class WorkloadApiClient:
             workload_pb2.X509BundlesRequest()
         )
         try:
-            item = next(response)
-        except StopIteration:
-            raise FetchX509BundleError('X.509 Bundles response is invalid')
+            try:
+                item = next(response)
+            except StopIteration:
+                raise FetchX509BundleError('X.509 Bundles response is invalid')
+        finally:
+            self._cancel_response_iterator(response)
         if len(item.bundles) == 0:
             raise FetchX509BundleError('X.509 Bundles response is empty')
         return item
@@ -619,12 +625,26 @@ class WorkloadApiClient:
             workload_pb2.JWTBundlesRequest()
         )
         try:
-            item = next(response)
-        except StopIteration:
-            raise FetchJwtBundleError('JWT Bundles response is invalid')
+            try:
+                item = next(response)
+            except StopIteration:
+                raise FetchJwtBundleError('JWT Bundles response is invalid')
+        finally:
+            self._cancel_response_iterator(response)
         if len(item.bundles) == 0:
             raise FetchJwtBundleError('JWT Bundles response is empty')
         return item
+
+    @staticmethod
+    def _cancel_response_iterator(response: object) -> None:
+        cancel = getattr(response, 'cancel', None)
+        if not callable(cancel):
+            return
+
+        try:
+            cancel()
+        except Exception as err:
+            _logger.debug('Error cancelling Workload API response stream: %s', err)
 
     @staticmethod
     def _create_x509_bundle_set(resp_bundles: Mapping[str, bytes]) -> X509BundleSet:

--- a/spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py
+++ b/spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py
@@ -16,6 +16,7 @@ under the License.
 
 from collections.abc import Iterator
 import threading
+from typing import Generic, TypeVar
 from unittest.mock import patch
 
 import grpc
@@ -50,6 +51,36 @@ from testutils.utils import (
     handle_error,
     assert_error,
 )
+
+_T = TypeVar('_T')
+
+
+class _FakeStream(Generic[_T]):
+    def __init__(
+        self,
+        responses: list[_T] | None = None,
+        *,
+        error: Exception | None = None,
+        cancel_error: Exception | None = None,
+    ) -> None:
+        self._responses = iter(responses or [])
+        self._error = error
+        self._cancel_error = cancel_error
+        self.cancel_count = 0
+
+    def __iter__(self) -> '_FakeStream[_T]':
+        return self
+
+    def __next__(self) -> _T:
+        if self._error:
+            raise self._error
+        return next(self._responses)
+
+    def cancel(self) -> bool:
+        self.cancel_count += 1
+        if self._cancel_error:
+            raise self._cancel_error
+        return True
 
 
 @pytest.fixture
@@ -88,6 +119,72 @@ def test_fetch_x509_svid_success(mocker: MockerFixture, client: WorkloadApiClien
     assert len(svid.cert_chain) == 2
     assert isinstance(svid.leaf, Certificate)
     assert isinstance(svid.private_key, ec.EllipticCurvePrivateKey)
+
+
+def test_fetch_x509_svid_success_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream = _FakeStream(
+        [
+            workload_pb2.X509SVIDResponse(
+                svids=[
+                    workload_pb2.X509SVID(
+                        spiffe_id='spiffe://example.org/service',
+                        x509_svid=CHAIN1,
+                        x509_svid_key=KEY1,
+                    )
+                ]
+            )
+        ]
+    )
+    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(return_value=stream)
+
+    svid = client.fetch_x509_svid()
+
+    assert svid.spiffe_id == SpiffeId('spiffe://example.org/service')
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_svid_empty_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream = _FakeStream([workload_pb2.X509SVIDResponse(svids=[])])
+    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509SvidError) as err:
+        client.fetch_x509_svid()
+
+    assert str(err.value) == 'Error fetching X.509 SVID: X.509 SVID response is empty'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_svid_invalid_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.X509SVIDResponse] = _FakeStream([])
+    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509SvidError) as err:
+        client.fetch_x509_svid()
+
+    assert str(err.value) == 'Error fetching X.509 SVID: X.509 SVID response is invalid'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_svid_exception_cancels_response_stream_without_masking_error(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.X509SVIDResponse] = _FakeStream(
+        error=Exception('stream failed'),
+        cancel_error=Exception('cancel failed'),
+    )
+    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509SvidError) as err:
+        client.fetch_x509_svid()
+
+    assert str(err.value) == 'Error fetching X.509 SVID: stream failed'
+    assert stream.cancel_count == 1
 
 
 def test_fetch_x509_svid_empty_response(
@@ -535,6 +632,61 @@ def test_fetch_x509_bundles_success(mocker: MockerFixture, client: WorkloadApiCl
     federated_bundle = bundle_set.get_bundle_for_trust_domain(TrustDomain('domain.test'))
     assert federated_bundle
     assert len(federated_bundle.x509_authorities) == 1
+
+
+def test_fetch_x509_bundles_success_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    bundles = {'example.org': BUNDLE}
+    stream = _FakeStream([workload_pb2.X509BundlesResponse(bundles=bundles)])
+    client._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(return_value=stream)
+
+    bundle_set = client.fetch_x509_bundles()
+
+    assert bundle_set.get_bundle_for_trust_domain(TrustDomain('example.org')) is not None
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_bundles_empty_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream = _FakeStream([workload_pb2.X509BundlesResponse(bundles={})])
+    client._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509BundleError) as err:
+        client.fetch_x509_bundles()
+
+    assert str(err.value) == 'Error fetching X.509 Bundle: X.509 Bundles response is empty'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_bundles_invalid_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.X509BundlesResponse] = _FakeStream([])
+    client._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509BundleError) as err:
+        client.fetch_x509_bundles()
+
+    assert str(err.value) == 'Error fetching X.509 Bundle: X.509 Bundles response is invalid'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_x509_bundles_exception_cancels_response_stream_without_masking_error(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.X509BundlesResponse] = _FakeStream(
+        error=Exception('stream failed'),
+        cancel_error=Exception('cancel failed'),
+    )
+    client._spiffe_workload_api_stub.FetchX509Bundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchX509BundleError) as err:
+        client.fetch_x509_bundles()
+
+    assert str(err.value) == 'Error fetching X.509 Bundle: stream failed'
+    assert stream.cancel_count == 1
 
 
 def test_fetch_x509_bundles_empty_response(

--- a/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
+++ b/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
@@ -16,7 +16,7 @@ under the License.
 
 from collections import deque
 from collections.abc import Iterator
-from typing import List
+from typing import Generic, List, TypeVar
 from unittest.mock import patch
 
 import pytest
@@ -51,6 +51,36 @@ from testutils.utils import (
     handle_error,
     assert_error,
 )
+
+_T = TypeVar('_T')
+
+
+class _FakeStream(Generic[_T]):
+    def __init__(
+        self,
+        responses: list[_T] | None = None,
+        *,
+        error: Exception | None = None,
+        cancel_error: Exception | None = None,
+    ) -> None:
+        self._responses = iter(responses or [])
+        self._error = error
+        self._cancel_error = cancel_error
+        self.cancel_count = 0
+
+    def __iter__(self) -> '_FakeStream[_T]':
+        return self
+
+    def __next__(self) -> _T:
+        if self._error:
+            raise self._error
+        return next(self._responses)
+
+    def cancel(self) -> bool:
+        self.cancel_count += 1
+        if self._cancel_error:
+            raise self._cancel_error
+        return True
 
 
 @pytest.fixture
@@ -213,6 +243,61 @@ def test_fetch_jwt_bundles(mocker: MockerFixture, client: WorkloadApiClient) -> 
     )
     assert federated_jwt_bundle
     assert len(federated_jwt_bundle.jwt_authorities) == 3
+
+
+def test_fetch_jwt_bundles_success_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    bundles = {'example.org': JWKS_1_EC_KEY}
+    stream = _FakeStream([workload_pb2.JWTBundlesResponse(bundles=bundles)])
+    client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(return_value=stream)
+
+    jwt_bundle_set = client.fetch_jwt_bundles()
+
+    assert jwt_bundle_set.get_bundle_for_trust_domain(TrustDomain('example.org')) is not None
+    assert stream.cancel_count == 1
+
+
+def test_fetch_jwt_bundles_empty_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream = _FakeStream([workload_pb2.JWTBundlesResponse(bundles={})])
+    client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchJwtBundleError) as exc_info:
+        client.fetch_jwt_bundles()
+
+    assert str(exc_info.value) == 'Error fetching JWT Bundle: JWT Bundles response is empty'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_jwt_bundles_invalid_response_cancels_response_stream(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.JWTBundlesResponse] = _FakeStream([])
+    client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchJwtBundleError) as exc_info:
+        client.fetch_jwt_bundles()
+
+    assert str(exc_info.value) == 'Error fetching JWT Bundle: JWT Bundles response is invalid'
+    assert stream.cancel_count == 1
+
+
+def test_fetch_jwt_bundles_exception_cancels_response_stream_without_masking_error(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    stream: _FakeStream[workload_pb2.JWTBundlesResponse] = _FakeStream(
+        error=Exception('stream failed'),
+        cancel_error=Exception('cancel failed'),
+    )
+    client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(return_value=stream)
+
+    with pytest.raises(FetchJwtBundleError) as exc_info:
+        client.fetch_jwt_bundles()
+
+    assert str(exc_info.value) == 'Error fetching JWT Bundle: stream failed'
+    assert stream.cancel_count == 1
 
 
 def test_fetch_jwt_bundles_empty_response(


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

`WorkloadApiClient` one-shot fetch helpers that wrap server-streaming Workload API RPCs: `_call_fetch_x509_svid`, `_call_fetch_x509_bundles`, and `_call_fetch_jwt_bundles`. Public methods that call these helpers (`fetch_x509_svid`, `fetch_x509_svids`, `fetch_x509_context`, `fetch_x509_bundles`, `fetch_jwt_bundles`) gain cleanup behavior without signature changes.

**Description of change**

After consuming the first streamed response (or when `next()` fails), the client now calls `cancel()` on the gRPC response iterator when that method exists, using `try`/`finally` so cancellation runs on success and error paths. If cancellation raises, the failure is logged at debug level only and does not replace the original fetch or validation error.

Added unit tests using a fake stream that records `cancel()` calls, covering success, empty stream, invalid/empty payload, and exception-from-stream paths for X.509 SVID, X.509 bundles, and JWT bundles.

Tests run:

- `uv run --group test pytest spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py`
- `uv run --group dev ruff check spiffe/src/spiffe/workloadapi/workload_api_client.py spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py`

**Which issue this PR fixes**

