### PR TITLE
fix(jwt-bundle): load only jwt-svid JWKs and reject invalid keys field

### DIFF
--- a/spiffe/src/spiffe/bundle/jwt_bundle/jwt_bundle.py
+++ b/spiffe/src/spiffe/bundle/jwt_bundle/jwt_bundle.py
@@ -18,11 +18,12 @@ under the License.
 JwtBundle module manages JwtBundle objects.
 """
 
+import json
 import threading
 from json import JSONDecodeError
 from jwt.api_jwk import PyJWKSet
 from jwt.exceptions import InvalidKeyError, PyJWKSetError
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, Any
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, dsa, ed25519, ed448
 
 from spiffe.spiffe_id.spiffe_id import TrustDomain
@@ -117,7 +118,25 @@ class JwtBundle(object):
             raise ArgumentError('Bundle bytes cannot be empty')
 
         try:
-            jwks = PyJWKSet.from_json(bundle_bytes.decode('utf-8'))
+            bundle_json = json.loads(bundle_bytes.decode('utf-8'))
+            if not isinstance(bundle_json, dict):
+                raise ParseJWTBundleError('"bundle_bytes" does not represent a valid jwks')
+
+            jwk_entries = bundle_json.get('keys')
+            if jwk_entries is None:
+                jwk_entries = []
+            elif not isinstance(jwk_entries, list):
+                raise ParseJWTBundleError('"bundle_bytes" does not represent a valid jwks')
+
+            jwt_svid_jwks: list[Dict[str, Any]] = [
+                jwk
+                for jwk in jwk_entries
+                if isinstance(jwk, dict) and jwk.get('use') == 'jwt-svid'
+            ]
+            if not jwt_svid_jwks:
+                return JwtBundle(trust_domain, {})
+
+            jwks = PyJWKSet.from_json(json.dumps({'keys': jwt_svid_jwks}))
 
             jwt_authorities = {}
             for jwk in jwks.keys:

--- a/spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py
+++ b/spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py
@@ -14,6 +14,8 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
+import json
+
 import pytest
 from typing import Dict
 from pytest_mock import MockerFixture
@@ -40,6 +42,30 @@ rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 authorities: Dict[str, _PUBLIC_KEY_TYPES] = {
     'kid1': ec_key.public_key(),
     'kid2': rsa_key.public_key(),
+}
+
+
+def _jwks_bytes(keys: list[dict[str, object]]) -> bytes:
+    return json.dumps({'keys': keys}).encode('utf-8')
+
+
+EC_JWT_SVID_KEY: dict[str, object] = {
+    "kty": "EC",
+    "use": "jwt-svid",
+    "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
+    "crv": "P-256",
+    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM",
+}
+
+EC_X509_SVID_KEY: dict[str, object] = {
+    **EC_JWT_SVID_KEY,
+    "use": "x509-svid",
+    "kid": "x509-key",
+}
+
+EC_MISSING_USE_KEY: dict[str, object] = {
+    key: value for key, value in EC_JWT_SVID_KEY.items() if key != "use"
 }
 
 
@@ -101,6 +127,61 @@ def test_parse(test_bytes: bytes, expected_authorities: int) -> None:
 
     assert jwt_bundle
     assert len(jwt_bundle.jwt_authorities) == expected_authorities
+
+
+def test_parse_mixed_jwt_svid_and_x509_svid_keys_only_loads_jwt_svid() -> None:
+    jwt_bundle = JwtBundle.parse(
+        trust_domain,
+        _jwks_bytes([EC_X509_SVID_KEY, EC_JWT_SVID_KEY]),
+    )
+
+    assert len(jwt_bundle.jwt_authorities) == 1
+    assert jwt_bundle.get_jwt_authority(str(EC_JWT_SVID_KEY["kid"])) is not None
+    assert jwt_bundle.get_jwt_authority(str(EC_X509_SVID_KEY["kid"])) is None
+
+
+def test_parse_no_jwt_svid_keys_produces_empty_bundle() -> None:
+    jwt_bundle = JwtBundle.parse(
+        trust_domain,
+        _jwks_bytes([EC_X509_SVID_KEY, EC_MISSING_USE_KEY]),
+    )
+
+    # SPIFFE bundle clients MUST ignore keys with missing or non-jwt-svid use.
+    assert jwt_bundle
+    assert len(jwt_bundle.jwt_authorities) == 0
+
+
+def test_parse_accepted_jwt_svid_key_without_kid_raises() -> None:
+    key_without_kid = {key: value for key, value in EC_JWT_SVID_KEY.items() if key != "kid"}
+
+    with pytest.raises(ParseJWTBundleError) as exception:
+        JwtBundle.parse(trust_domain, _jwks_bytes([key_without_kid]))
+
+    assert (
+        str(exception.value)
+        == 'Error parsing JWT bundle: Error adding authority from JWKS: "keyID" cannot be empty'
+    )
+
+
+def test_parse_malformed_jwt_svid_key_raises_parse_error() -> None:
+    malformed_jwt_svid_key = {
+        key: value for key, value in EC_JWT_SVID_KEY.items() if key != "x"
+    }
+
+    with pytest.raises(ParseJWTBundleError) as exception:
+        JwtBundle.parse(trust_domain, _jwks_bytes([malformed_jwt_svid_key]))
+
+    assert str(exception.value).startswith('Error parsing JWT bundle: ')
+
+
+def test_parse_malformed_non_jwt_svid_key_is_ignored() -> None:
+    malformed_x509_svid_key = {
+        key: value for key, value in EC_X509_SVID_KEY.items() if key != "x"
+    }
+
+    jwt_bundle = JwtBundle.parse(trust_domain, _jwks_bytes([malformed_x509_svid_key]))
+
+    assert len(jwt_bundle.jwt_authorities) == 0
 
 
 def test_parse_invalid_trust_domain() -> None:
@@ -168,3 +249,17 @@ def test_parse_jwks_with_null_keys_field() -> None:
 
     assert bundle
     assert len(bundle.jwt_authorities) == 0
+
+
+@pytest.mark.parametrize(
+    'invalid_keys_json',
+    ['{"keys": false}', '{"keys": ""}', '{"keys": 0}'],
+)
+def test_parse_jwks_with_invalid_keys_type_raises(invalid_keys_json: str) -> None:
+    with pytest.raises(ParseJWTBundleError) as exception:
+        JwtBundle.parse(trust_domain, invalid_keys_json.encode('utf-8'))
+
+    assert (
+        str(exception.value)
+        == 'Error parsing JWT bundle: "bundle_bytes" does not represent a valid jwks'
+    )

--- a/testutils/src/testutils/jwks/jwks_1_ec_key.json
+++ b/testutils/src/testutils/jwks/jwks_1_ec_key.json
@@ -2,6 +2,7 @@
     "keys": [
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
             "crv": "P-256",
             "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",

--- a/testutils/src/testutils/jwks/jwks_3_keys.json
+++ b/testutils/src/testutils/jwks/jwks_3_keys.json
@@ -2,6 +2,7 @@
     "keys": [
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
             "crv": "P-256",
             "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
@@ -9,6 +10,7 @@
         },
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "kid": "gHTCunJbefYtnZnTctd84xeRWyMrEsWD",
             "crv": "P-256",
             "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
@@ -16,6 +18,7 @@
         },
         {
             "kty":"RSA",
+            "use": "jwt-svid",
             "kid":"2011-04-29",
             "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
             "e":"AQAB"

--- a/testutils/src/testutils/jwks/jwks_ec_missing_x.json
+++ b/testutils/src/testutils/jwks/jwks_ec_missing_x.json
@@ -2,6 +2,7 @@
     "keys": [
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
             "crv": "P-256",
             "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"

--- a/testutils/src/testutils/jwks/jwks_missing_kid.json
+++ b/testutils/src/testutils/jwks/jwks_missing_kid.json
@@ -2,6 +2,7 @@
     "keys": [
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
             "crv": "P-256",
             "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
@@ -9,6 +10,7 @@
         },
         {
             "kty": "EC",
+            "use": "jwt-svid",
             "crv": "P-256",
             "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
             "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

`JwtBundle.parse()` when loading SPIFFE JWT bundles from JWKS bytes: which JWK entries become `jwt_authorities`, handling of mixed SVID key types in one JWKS, and parsing of the top-level `keys` field.

**Description of change**

- Parse JWKS as JSON first, then keep only JWK objects with `use == "jwt-svid"` (case-sensitive), consistent with SPIFFE bundle and JWT-SVID docs; entries with missing or non–`jwt-svid` `use` are ignored.
- If there are no `jwt-svid` keys after filtering, return an empty `JwtBundle`.
- Preserve the existing rule that accepted keys must have a non-empty `kid`.
- Treat `keys` missing or `null` as an empty key list; reject other non-list `keys` values (for example boolean, string, number) with `ParseJWTBundleError` instead of silently producing an empty bundle.
- Extended unit tests (mixed `use`, empty after filter, `kid`, malformed accepted vs ignored keys, invalid `keys` types). Updated shared JWKS test fixtures with `use: "jwt-svid"` where needed. Added `spiffe/CHANGELOG.md` **Unreleased** note.

Tests run: `uv run --group test pytest spiffe/tests/unit/bundle/jwt_bundle/test_jwt_bundle.py` (and any broader suite you use before merge).

**Which issue this PR fixes**

