### PR TITLE
chore(release): bump spiffe to 0.2.9 and spiffe-tls to 0.3.2

### DIFF
--- a/spiffe-tls/CHANGELOG.md
+++ b/spiffe-tls/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.2] - 2026-05-11
+
+### Fixed
+
+- **TLS peer authorization:** Parse SPIFFE URI subject alternative names safely during peer certificate authorization.
+
+### Changed
+
+- **Dependencies:** Require `spiffe>=0.2.9` so `spiffe-tls` installs stay aligned with the current core release line.
+
+
 ## [0.3.1] – 2026-03-15
 
 ### Development

--- a/spiffe-tls/pyproject.toml
+++ b/spiffe-tls/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "spiffe-tls"
-version = "0.3.1"
+version = "0.3.2"
 description = "TLS Support using SPIFFE"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [{ name = "Max Lambrecht", email = "maxlambrecht@gmail.com" }]
 dependencies = [
-  "spiffe>=0.2.3,<0.3.0",
+  "spiffe>=0.2.9,<0.3.0",
   "pyOpenSSL>=26,<27",
   "idna>=3,<4",
 ]

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.9] - 2026-05-11
+
+### Fixed
+
+- **Workload API:** Cancel server-stream RPC iterators after one-shot `Fetch*` calls, so gRPC streaming RPCs are not left open.
+- **Workload API sources:** Close the source after `JwtSource` or `X509Source` initialization failures and fatal stream errors. This cancels the stream and closes an owned `WorkloadApiClient`, preventing connection and background-task leaks.
+- **X.509:** Write private key material with restrictive POSIX file permissions (`0o600`) at file creation time, including when overwriting an existing key file.
+
+
 ## [0.2.8] – 2026-05-08
 
 ### Changed

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.2.8"
+version = "0.2.9"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },
@@ -1081,7 +1081,7 @@ dev = [
 
 [[package]]
 name = "spiffe-tls"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "spiffe-tls" }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
**What**

- Release **spiffe 0.2.9** and **spiffe-tls 0.3.2** with version bumps in each package’s `pyproject.toml`.
- Document **spiffe 0.2.9** in `spiffe/CHANGELOG.md`:
  - Cancel server-stream iterators after one-shot Workload API `Fetch*` calls.
  - Ensure `JwtSource` and `X509Source` shut down cleanly after initialization failures or fatal stream errors, including stream cancellation and closing an owned `WorkloadApiClient`.
  - Write X.509 private key material with restrictive POSIX permissions (`0o600`) at file creation time, including when overwriting an existing key file.
- Document **spiffe-tls 0.3.2** in `spiffe-tls/CHANGELOG.md`:
  - Parse SPIFFE URI subject alternative names safely during TLS peer authorization.
  - Require **`spiffe>=0.2.9,<0.3.0`** so `spiffe-tls` installs stay aligned with the compatible core release line.
- Refresh **`uv.lock`** for the new package versions and dependency constraint.

**Why**

Ships fixes already merged on `main` since **spiffe 0.2.8** and **spiffe-tls 0.3.1**, covering Workload API lifecycle cleanup, private key file permissions, and TLS peer authorization hardening.

This also keeps `spiffe-tls` constrained to the compatible **spiffe 0.2.x** release line while requiring the latest patch that contains the relevant core fixes.

**How tested**

- `./dev lint`
- `./dev build`
- `./dev test`
- `./dev integration`