### PR TITLE
fix(workloadapi): add deadlines to blocking fetch calls

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Workload API:** Added `default_timeout` to `WorkloadApiClient` and per-call `timeout` arguments to blocking fetch and JWT validation methods. Per-call timeouts override the client default; `None` preserves the previous unbounded behavior. Streaming methods are unchanged.
+- **JwtSource:** Added per-call `timeout` to `fetch_svid` and `fetch_svids`, passed through to the underlying `WorkloadApiClient`.
+
 ## [0.2.9] - 2026-05-11
 
 ### Fixed

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -42,6 +42,20 @@ with WorkloadApiClient() as client:
     print(f'SPIFFE ID: {jwt_svid.spiffe_id}')
 ```
 
+By default, blocking Workload API calls wait without a deadline. To avoid
+indefinitely blocking a calling thread when the Workload API is unresponsive,
+set `default_timeout` on the client or pass a per-call `timeout` in seconds:
+
+```python
+with WorkloadApiClient(default_timeout=5.0) as client:
+    jwt_svid = client.fetch_jwt_svid(audience={"test"})
+    jwt_svid = client.fetch_jwt_svid(audience={"test"}, timeout=1.0)
+```
+
+Per-call timeouts override `default_timeout`. Deadline expiry is reported as
+the SPIFFE-specific error for the call, such as `FetchJwtSvidError`. Timeouts do
+not apply to long-lived streaming methods.
+
 ### X509Source
 
 ```python

--- a/spiffe/src/spiffe/workloadapi/jwt_source.py
+++ b/spiffe/src/spiffe/workloadapi/jwt_source.py
@@ -119,12 +119,18 @@ class JwtSource:
                 raise JwtSourceError('Cannot get Jwt Bundles: source is closed')
             return frozenset(self._jwt_bundle_set.bundles)
 
-    def fetch_svid(self, audience: Set[str], subject: Optional[SpiffeId] = None) -> JwtSvid:
+    def fetch_svid(
+        self,
+        audience: Set[str],
+        subject: Optional[SpiffeId] = None,
+        timeout: Optional[float] = None,
+    ) -> JwtSvid:
         """Fetches an JWT-SVID from the source.
 
         Args:
             audience: List of audiences for the JWT SVID.
             subject: SPIFFE ID subject for the JWT.
+            timeout: Deadline in seconds for the Workload API call. Overrides the client default.
 
         Raises:
             ArgumentError: In case audiences is empty.
@@ -133,17 +139,21 @@ class JwtSource:
         if not audience:
             raise ArgumentError('Audience cannot be empty')
 
-        jwt_svid = self._workload_api_client.fetch_jwt_svid(audience, subject)
+        jwt_svid = self._workload_api_client.fetch_jwt_svid(audience, subject, timeout=timeout)
         return jwt_svid
 
     def fetch_svids(
-        self, audiences: Set[str], subject: Optional[SpiffeId] = None
+        self,
+        audiences: Set[str],
+        subject: Optional[SpiffeId] = None,
+        timeout: Optional[float] = None,
     ) -> List[JwtSvid]:
         """Fetches all JWT-SVIDs from the source.
 
         Args:
             audiences: List of audiences for the JWT SVID.
             subject: SPIFFE ID subject for the JWT.
+            timeout: Deadline in seconds for the Workload API call. Overrides the client default.
 
         Raises:
             ArgumentError: In case audiences is empty.
@@ -152,7 +162,9 @@ class JwtSource:
         if not audiences:
             raise ArgumentError('Audience cannot be empty')
 
-        jwt_svid = self._workload_api_client.fetch_jwt_svids(audiences, subject)
+        jwt_svid = self._workload_api_client.fetch_jwt_svids(
+            audiences, subject, timeout=timeout
+        )
         return jwt_svid
 
     def get_bundle_for_trust_domain(self, trust_domain: TrustDomain) -> Optional[JwtBundle]:

--- a/spiffe/src/spiffe/workloadapi/workload_api_client.py
+++ b/spiffe/src/spiffe/workloadapi/workload_api_client.py
@@ -183,7 +183,11 @@ class StreamCancelHandler:
 class WorkloadApiClient:
     """A SPIFFE Workload API Client."""
 
-    def __init__(self, socket_path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        socket_path: Optional[str] = None,
+        default_timeout: Optional[float] = None,
+    ) -> None:
         """
         Creates a new Workload API Client.
 
@@ -193,11 +197,18 @@ class WorkloadApiClient:
         Parameters:
             socket_path (Optional[str]): The file path to the Workload API UDS. If omitted, the client looks for the
                                         path in the `SPIFFE_ENDPOINT_SOCKET` environment variable.
+            default_timeout (Optional[float]): Default deadline, in seconds, applied to every blocking
+                                        Workload API call (the one-shot fetch and validate methods). Each
+                                        call may override it with its own `timeout` argument. When `None`
+                                        (the default), calls block without a deadline, preserving the
+                                        previous behavior. This deadline does not apply to the long-lived
+                                        streaming methods (`stream_x509_contexts`, `stream_jwt_bundles`).
 
         Raises:
             ArgumentError: If `socket_path` is not provided and no path is found in the `SPIFFE_ENDPOINT_SOCKET`
                            environment variable, or if the provided `socket_path` is invalid.
         """
+        self._default_timeout = default_timeout
         try:
             self._config = ConfigSetter(spiffe_endpoint_socket=socket_path).get_config()
             self._check_spiffe_socket_exists(self._config.spiffe_endpoint_socket)
@@ -210,9 +221,16 @@ class WorkloadApiClient:
             workload_pb2_grpc.SpiffeWorkloadAPIStub(self._channel)  # type: ignore[no-untyped-call]
         )
 
+    def _resolve_timeout(self, timeout: Optional[float]) -> Optional[float]:
+        """Returns the per-call timeout when provided, otherwise the client default."""
+        return timeout if timeout is not None else self._default_timeout
+
     @handle_error(error_cls=FetchX509SvidError)
-    def fetch_x509_svid(self) -> X509Svid:
+    def fetch_x509_svid(self, timeout: Optional[float] = None) -> X509Svid:
         """Fetches the default X509-SVID, i.e. the first in the list returned by the Workload API.
+
+        Args:
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             X509Svid: Instance of X509Svid object.
@@ -221,15 +239,18 @@ class WorkloadApiClient:
             FetchX509SvidError: When there is an error fetching the X.509 SVID from the Workload API, or when the
                                 response payload cannot be processed to be converted to a X509Svid object.
         """
-        response = self._call_fetch_x509_svid()
+        response = self._call_fetch_x509_svid(self._resolve_timeout(timeout))
 
         svid = response.svids[0]
 
         return self._create_x509_svid(svid)
 
     @handle_error(error_cls=FetchX509SvidError)
-    def fetch_x509_svids(self) -> List[X509Svid]:
+    def fetch_x509_svids(self, timeout: Optional[float] = None) -> List[X509Svid]:
         """Fetches all X509-SVIDs.
+
+        Args:
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             X509Svid: List of of X509Svid object.
@@ -238,7 +259,7 @@ class WorkloadApiClient:
             FetchX509SvidError: When there is an error fetching the X.509 SVID from the Workload API, or when the
                                 response payload cannot be processed to be converted to a X509Svid object.
         """
-        response = self._call_fetch_x509_svid()
+        response = self._call_fetch_x509_svid(self._resolve_timeout(timeout))
 
         result = []
         for svid in response.svids:
@@ -247,8 +268,11 @@ class WorkloadApiClient:
         return result
 
     @handle_error(error_cls=FetchX509SvidError)
-    def fetch_x509_context(self) -> X509Context:
+    def fetch_x509_context(self, timeout: Optional[float] = None) -> X509Context:
         """Fetches an X.509 context (X.509 SVIDs and X.509 Bundles keyed by TrustDomain).
+
+        Args:
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             X509Context: An object containing a List of X509Svids and a X509BundleSet.
@@ -260,12 +284,15 @@ class WorkloadApiClient:
             FetchX509BundleError: When there is an error fetching the X.509 Bundles from the Workload API, or when the
                                   response payload cannot be processed to be converted to a X509Bundle objects.
         """
-        response = self._call_fetch_x509_svid()
+        response = self._call_fetch_x509_svid(self._resolve_timeout(timeout))
         return self._process_x509_context(response)
 
     @handle_error(error_cls=FetchX509BundleError)
-    def fetch_x509_bundles(self) -> X509BundleSet:
+    def fetch_x509_bundles(self, timeout: Optional[float] = None) -> X509BundleSet:
         """Fetches X.509 bundles, keyed by trust domain.
+
+        Args:
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             X509BundleSet: Set of X509Bundle objects.
@@ -274,18 +301,22 @@ class WorkloadApiClient:
             FetchX509BundleError: When there is an error fetching the X.509 Bundles from the Workload API, or when the
                                   response payload cannot be processed to be converted to a X509Bundle objects.
         """
-        response = self._call_fetch_x509_bundles()
+        response = self._call_fetch_x509_bundles(self._resolve_timeout(timeout))
         return self._create_x509_bundle_set(response.bundles)
 
     @handle_error(error_cls=FetchJwtSvidError)
     def fetch_jwt_svid(
-        self, audience: Set[str], subject: Optional[SpiffeId] = None
+        self,
+        audience: Set[str],
+        subject: Optional[SpiffeId] = None,
+        timeout: Optional[float] = None,
     ) -> JwtSvid:
         """Fetches a SPIFFE JWT-SVID.
 
         Args:
             audience: Set of audiences for the JWT SVID.
             subject: SPIFFE ID subject for the JWT.
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             JwtSvid: Instance of JwtSvid object.
@@ -301,7 +332,8 @@ class WorkloadApiClient:
             workload_pb2.JWTSVIDRequest(
                 audience=audience,
                 spiffe_id=subject_str,
-            )
+            ),
+            timeout=self._resolve_timeout(timeout),
         )
 
         if len(response.svids) == 0:
@@ -312,13 +344,17 @@ class WorkloadApiClient:
 
     @handle_error(error_cls=FetchJwtSvidError)
     def fetch_jwt_svids(
-        self, audience: Set[str], subject: Optional[SpiffeId] = None
+        self,
+        audience: Set[str],
+        subject: Optional[SpiffeId] = None,
+        timeout: Optional[float] = None,
     ) -> List[JwtSvid]:
         """Fetches all SPIFFE JWT-SVIDs.
 
         Args:
             audience: List of audiences for the JWT SVID.
             subject: SPIFFE ID subject for the JWT.
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Raises:
             ArgumentError: In case audience is empty.
@@ -332,7 +368,8 @@ class WorkloadApiClient:
             workload_pb2.JWTSVIDRequest(
                 audience=audience,
                 spiffe_id=subject_str,
-            )
+            ),
+            timeout=self._resolve_timeout(timeout),
         )
 
         if len(response.svids) == 0:
@@ -345,8 +382,11 @@ class WorkloadApiClient:
         return svids
 
     @handle_error(error_cls=FetchJwtBundleError)
-    def fetch_jwt_bundles(self) -> JwtBundleSet:
+    def fetch_jwt_bundles(self, timeout: Optional[float] = None) -> JwtBundleSet:
         """Fetches the JWT bundles for JWT-SVID validation, keyed by trust domain.
+
+        Args:
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             JwtBundleSet: Set of JwtBundle objects.
@@ -355,17 +395,20 @@ class WorkloadApiClient:
             FetchJwtBundleError: In case there is an error in fetching the JWT-Bundle from the Workload API or
                                 in case the set of jwt_authorities cannot be parsed from the Workload API Response.
         """
-        response = self._call_fetch_jwt_bundles()
+        response = self._call_fetch_jwt_bundles(self._resolve_timeout(timeout))
         jwt_bundles: Dict[TrustDomain, JwtBundle] = self._create_td_jwt_bundle_dict(response)
         return JwtBundleSet(jwt_bundles)
 
     @handle_error(error_cls=ValidateJwtSvidError)
-    def validate_jwt_svid(self, token: str, audience: str) -> JwtSvid:
+    def validate_jwt_svid(
+        self, token: str, audience: str, timeout: Optional[float] = None
+    ) -> JwtSvid:
         """Validates the JWT-SVID token. The parsed and validated JWT-SVID is returned.
 
         Args:
             token: JWT to validate.
             audience: expected audience to validate against.
+            timeout: Deadline in seconds for this call. Overrides the client default.
 
         Returns:
             JwtSvid: If the token and audience could be validated.
@@ -384,7 +427,8 @@ class WorkloadApiClient:
             workload_pb2.ValidateJWTSVIDRequest(
                 audience=audience,
                 svid=token,
-            )
+            ),
+            timeout=self._resolve_timeout(timeout),
         )
         return JwtSvid.parse_insecure(token, {audience})
 
@@ -592,8 +636,12 @@ class WorkloadApiClient:
 
         return grpc.intercept_channel(grpc_insecure_channel, spiffe_client_interceptor)
 
-    def _call_fetch_x509_svid(self) -> workload_pb2.X509SVIDResponse:
-        response = self._spiffe_workload_api_stub.FetchX509SVID(workload_pb2.X509SVIDRequest())
+    def _call_fetch_x509_svid(
+        self, timeout: Optional[float] = None
+    ) -> workload_pb2.X509SVIDResponse:
+        response = self._spiffe_workload_api_stub.FetchX509SVID(
+            workload_pb2.X509SVIDRequest(), timeout=timeout
+        )
         try:
             try:
                 item = next(response)
@@ -605,9 +653,11 @@ class WorkloadApiClient:
             raise FetchX509SvidError('X.509 SVID response is empty')
         return item
 
-    def _call_fetch_x509_bundles(self) -> workload_pb2.X509BundlesResponse:
+    def _call_fetch_x509_bundles(
+        self, timeout: Optional[float] = None
+    ) -> workload_pb2.X509BundlesResponse:
         response = self._spiffe_workload_api_stub.FetchX509Bundles(
-            workload_pb2.X509BundlesRequest()
+            workload_pb2.X509BundlesRequest(), timeout=timeout
         )
         try:
             try:
@@ -620,9 +670,11 @@ class WorkloadApiClient:
             raise FetchX509BundleError('X.509 Bundles response is empty')
         return item
 
-    def _call_fetch_jwt_bundles(self) -> workload_pb2.JWTBundlesResponse:
+    def _call_fetch_jwt_bundles(
+        self, timeout: Optional[float] = None
+    ) -> workload_pb2.JWTBundlesResponse:
         response = self._spiffe_workload_api_stub.FetchJWTBundles(
-            workload_pb2.JWTBundlesRequest()
+            workload_pb2.JWTBundlesRequest(), timeout=timeout
         )
         try:
             try:

--- a/spiffe/tests/unit/workloadapi/test_jwt_source.py
+++ b/spiffe/tests/unit/workloadapi/test_jwt_source.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Iterator
 import threading
 import time
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from pytest_mock import MockerFixture
@@ -230,6 +230,49 @@ def test_get_jwt_svid_no_subject(mocker: MockerFixture, client: WorkloadApiClien
 
     assert jwt_svid._spiffe_id == SPIFFE_ID
     assert jwt_svid._audience == TEST_AUDIENCE
+
+
+def test_fetch_svid_passes_timeout_to_client(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    mock_client_get_jwt_svid(mocker, client)
+    mock_client_fetch_jwt_bundles(mocker, client)
+    fetch_spy = mocker.spy(client, 'fetch_jwt_svid')
+
+    jwt_source = JwtSource(client)
+    jwt_source.fetch_svid(TEST_AUDIENCE, subject=SPIFFE_ID, timeout=4.0)
+
+    assert fetch_spy.call_args.kwargs['timeout'] == 4.0
+    fetch_jwt_svid_stub = cast(Mock, client._spiffe_workload_api_stub.FetchJWTSVID)
+    assert fetch_jwt_svid_stub.call_args.kwargs['timeout'] == 4.0
+
+
+def test_fetch_svids_passes_timeout_to_client(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    mock_client_get_jwt_svid(mocker, client)
+    mock_client_fetch_jwt_bundles(mocker, client)
+    fetch_spy = mocker.spy(client, 'fetch_jwt_svids')
+
+    jwt_source = JwtSource(client)
+    jwt_source.fetch_svids(TEST_AUDIENCE, subject=SPIFFE_ID, timeout=4.0)
+
+    assert fetch_spy.call_args.kwargs['timeout'] == 4.0
+    fetch_jwt_svid_stub = cast(Mock, client._spiffe_workload_api_stub.FetchJWTSVID)
+    assert fetch_jwt_svid_stub.call_args.kwargs['timeout'] == 4.0
+
+
+def test_fetch_svid_defaults_timeout_to_none(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    mock_client_get_jwt_svid(mocker, client)
+    mock_client_fetch_jwt_bundles(mocker, client)
+
+    jwt_source = JwtSource(client)
+    jwt_source.fetch_svid(TEST_AUDIENCE, subject=SPIFFE_ID)
+
+    fetch_jwt_svid_stub = cast(Mock, client._spiffe_workload_api_stub.FetchJWTSVID)
+    assert fetch_jwt_svid_stub.call_args.kwargs['timeout'] is None
 
 
 def test_get_jwt_svid_exception(mocker: MockerFixture, client: WorkloadApiClient) -> None:

--- a/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
+++ b/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
@@ -171,6 +171,106 @@ def test_fetch_jwt_svids(mocker: MockerFixture, client: WorkloadApiClient) -> No
     assert int(svid._expiry) > utc_time
 
 
+@pytest.fixture
+def client_with_default_timeout() -> WorkloadApiClient:
+    with patch.object(WorkloadApiClient, '_check_spiffe_socket_exists') as mock_check:
+        mock_check.return_value = None
+        client_instance = WorkloadApiClient('unix:///dummy.path', default_timeout=7.5)
+    return client_instance
+
+
+def test_fetch_jwt_svid_per_call_timeout_passed_to_stub(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    spiffe_id = 'spiffe://test.com/my_service'
+    jwt_svid = generate_test_jwt_token(spiffe_id=spiffe_id)
+    stub = mocker.Mock(
+        return_value=workload_pb2.JWTSVIDResponse(svids=[workload_pb2.JWTSVID(svid=jwt_svid)])
+    )
+    client._spiffe_workload_api_stub.FetchJWTSVID = stub
+
+    client.fetch_jwt_svid(audience=TEST_AUDIENCE, timeout=3.0)
+
+    assert stub.call_args.kwargs['timeout'] == 3.0
+
+
+def test_fetch_jwt_svid_uses_default_timeout(
+    mocker: MockerFixture, client_with_default_timeout: WorkloadApiClient
+) -> None:
+    spiffe_id = 'spiffe://test.com/my_service'
+    jwt_svid = generate_test_jwt_token(spiffe_id=spiffe_id)
+    stub = mocker.Mock(
+        return_value=workload_pb2.JWTSVIDResponse(svids=[workload_pb2.JWTSVID(svid=jwt_svid)])
+    )
+    client_with_default_timeout._spiffe_workload_api_stub.FetchJWTSVID = stub
+
+    client_with_default_timeout.fetch_jwt_svid(audience=TEST_AUDIENCE)
+
+    assert stub.call_args.kwargs['timeout'] == 7.5
+
+
+def test_fetch_jwt_svid_per_call_timeout_overrides_default(
+    mocker: MockerFixture, client_with_default_timeout: WorkloadApiClient
+) -> None:
+    spiffe_id = 'spiffe://test.com/my_service'
+    jwt_svid = generate_test_jwt_token(spiffe_id=spiffe_id)
+    stub = mocker.Mock(
+        return_value=workload_pb2.JWTSVIDResponse(svids=[workload_pb2.JWTSVID(svid=jwt_svid)])
+    )
+    client_with_default_timeout._spiffe_workload_api_stub.FetchJWTSVID = stub
+
+    client_with_default_timeout.fetch_jwt_svid(audience=TEST_AUDIENCE, timeout=1.0)
+
+    assert stub.call_args.kwargs['timeout'] == 1.0
+
+
+def test_fetch_jwt_svid_no_timeout_defaults_to_none(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    spiffe_id = 'spiffe://test.com/my_service'
+    jwt_svid = generate_test_jwt_token(spiffe_id=spiffe_id)
+    stub = mocker.Mock(
+        return_value=workload_pb2.JWTSVIDResponse(svids=[workload_pb2.JWTSVID(svid=jwt_svid)])
+    )
+    client._spiffe_workload_api_stub.FetchJWTSVID = stub
+
+    client.fetch_jwt_svid(audience=TEST_AUDIENCE)
+
+    assert stub.call_args.kwargs['timeout'] is None
+
+
+def test_validate_jwt_svid_timeout_passed_to_stub(
+    mocker: MockerFixture, client_with_default_timeout: WorkloadApiClient
+) -> None:
+    audience = 'spire'
+    spiffe_id = 'spiffe://test.com/my_service'
+    jwt_svid = generate_test_jwt_token(audience={audience}, spiffe_id=spiffe_id)
+    stub = mocker.Mock(return_value=workload_pb2.ValidateJWTSVIDResponse(spiffe_id=spiffe_id))
+    client_with_default_timeout._spiffe_workload_api_stub.ValidateJWTSVID = stub
+
+    client_with_default_timeout.validate_jwt_svid(token=jwt_svid, audience=audience)
+    assert stub.call_args.kwargs['timeout'] == 7.5
+
+    client_with_default_timeout.validate_jwt_svid(
+        token=jwt_svid, audience=audience, timeout=2.0
+    )
+    assert stub.call_args.kwargs['timeout'] == 2.0
+
+
+def test_validate_jwt_svid_deadline_exceeded_surfaced(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    jwt_svid = generate_test_jwt_token()
+    grpc_error = FakeCall()
+    grpc_error._code = grpc.StatusCode.DEADLINE_EXCEEDED
+    client._spiffe_workload_api_stub.ValidateJWTSVID = mocker.Mock(side_effect=grpc_error)
+
+    with pytest.raises(ValidateJwtSvidError) as exception:
+        client.validate_jwt_svid(token=jwt_svid, audience='audience', timeout=0.001)
+
+    assert 'StatusCode.DEADLINE_EXCEEDED' in str(exception.value)
+
+
 def test_fetch_jwt_svid_no_audience(client: WorkloadApiClient) -> None:
     with pytest.raises(ArgumentError) as exception:
         client.fetch_jwt_svid(audience=set())

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6.31.1,<8" },
     { name = "pyasn1", specifier = ">=0.6.0,<0.7.0" },
     { name = "pyasn1-modules", specifier = ">=0.4.0,<0.5.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2,<2.13" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2,<2.14" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What

- Add `default_timeout` to `WorkloadApiClient` for blocking one-shot Workload API calls.
- Add per-call `timeout` arguments to blocking fetch and JWT validation methods.
- Add per-call timeout pass-through for `JwtSource.fetch_svid` and `JwtSource.fetch_svids`.
- Document timeout behavior and add changelog entries.

Fixes #434

## Why

Blocking unary Workload API calls previously had no caller-controlled gRPC deadline. If the SPIRE agent stopped responding, caller threads could block indefinitely and exhaust worker pools in threaded services.

The new API preserves existing behavior by default (`None` remains unbounded), while allowing deployments to set safe deadlines once on the client or override them per call.

## How tested

- `uv run pytest spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py spiffe/tests/unit/workloadapi/test_jwt_source.py -q`
- `uv run mypy spiffe/src/spiffe/workloadapi/workload_api_client.py spiffe/src/spiffe/workloadapi/jwt_source.py`
- `uv run ruff format --check spiffe/src/spiffe/workloadapi/workload_api_client.py spiffe/src/spiffe/workloadapi/jwt_source.py spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py spiffe/tests/unit/workloadapi/test_jwt_source.py`