### PR TITLE
chore(release): bump spiffe to 0.2.10

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.10] - 2026-06-07
 
 ### Added
 - **Workload API:** Added `default_timeout` to `WorkloadApiClient` and per-call `timeout` arguments to blocking fetch and JWT validation methods. Per-call timeouts override the client default; `None` preserves the previous unbounded behavior. Streaming methods are unchanged.

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.2.9"
+version = "0.2.10"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

- Bump `spiffe` from `0.2.9` to `0.2.10`.
- Move the Workload API timeout changelog notes into the `0.2.10` release section.
- Update `uv.lock` to match the released `spiffe` package version.

## Why

This prepares a patch release for the Workload API timeout fix, which adds configurable deadlines for blocking fetch and JWT validation calls while preserving the previous unbounded behavior by default.
