### PR TITLE
chore(release): prepare spiffe 0.3.0 and spiffe-tls 0.4.0

### DIFF
--- a/spiffe-tls/CHANGELOG.md
+++ b/spiffe-tls/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.0] - 2026-06-15
+
+### Changed
+
+- **Dependencies:** Require `spiffe>=0.3.0,<0.4.0` so `spiffe-tls` installs resolve against the corrected `spiffe` `0.3.x` release line.
+
 ## [0.3.2] - 2026-05-11
 
 ### Fixed

--- a/spiffe-tls/pyproject.toml
+++ b/spiffe-tls/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "spiffe-tls"
-version = "0.3.2"
+version = "0.4.0"
 description = "TLS Support using SPIFFE"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [{ name = "Max Lambrecht", email = "maxlambrecht@gmail.com" }]
 dependencies = [
-  "spiffe>=0.2.9,<0.3.0",
+  "spiffe>=0.3.0,<0.4.0",
   "pyOpenSSL>=26,<27",
   "idna>=3,<4",
 ]

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## [0.2.10] - 2026-06-07
+## [0.3.0] - 2026-06-15
+
+### Breaking
+- This release contains changes originally published as `0.2.10`. Because those changes are not patch-compatible, `0.2.10` has been yanked and the changes are republished as `0.3.0`.
 
 ### Added
 - **Workload API:** Added `default_timeout` to `WorkloadApiClient` and per-call `timeout` arguments to blocking fetch and JWT validation methods. Per-call timeouts override the client default; `None` preserves the previous unbounded behavior. Streaming methods are unchanged.
 - **JwtSource:** Added per-call `timeout` to `fetch_svid` and `fetch_svids`, passed through to the underlying `WorkloadApiClient`.
+
+## [0.2.10] - 2026-06-07 [YANKED]
+
+### Yanked
+- Yanked because it included changes that were not patch-compatible. Use `0.3.0` instead.
 
 ## [0.2.9] - 2026-05-11
 

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.2.10"
+version = "0.3.0"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.2.10"
+version = "0.3.0"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },
@@ -1081,7 +1081,7 @@ dev = [
 
 [[package]]
 name = "spiffe-tls"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "spiffe-tls" }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
## What

- Bump `spiffe` from `0.2.10` to `0.3.0`.
- Mark `spiffe 0.2.10` as yanked in the changelog because it included non-patch-compatible changes.
- Bump `spiffe-tls` from `0.3.2` to `0.4.0`.
- Update `spiffe-tls` to require `spiffe>=0.3.0,<0.4.0`.
- Refresh `uv.lock`.

Fixes #439

## Why

`spiffe 0.2.10` was released with breaking changes under a patch version. This republishes those changes as `spiffe 0.3.0` and aligns `spiffe-tls` with the corrected core release line without presenting the dependency change as patch-compatible.
