### PR TITLE
Disable 'iat' field verification

### DIFF
--- a/spiffe/src/spiffe/svid/jwt_svid.py
+++ b/spiffe/src/spiffe/svid/jwt_svid.py
@@ -176,6 +176,7 @@ class JwtSvid(object):
                     'verify_signature': True,
                     'verify_aud': True,
                     'verify_exp': True,
+                    'verify_iat': False,
                 },
             )
 

--- a/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
+++ b/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
@@ -337,8 +337,7 @@ def test_parse_and_validate_valid_token_future_iat() -> None:
     """
     future_iat = timegm(
         (
-            datetime.datetime.now(datetime.timezone.utc)
-            + datetime.timedelta(hours=1)
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
         ).utctimetuple()
     )
     token = jwt.encode(
@@ -358,7 +357,9 @@ def test_parse_and_validate_valid_token_future_iat() -> None:
     assert jwt_svid._audience == TEST_AUDIENCE
     assert str(jwt_svid._spiffe_id) == TEST_SPIFFE_ID
     assert jwt_svid._expiry == TEST_EXPIRY
-    assert jwt_svid._claims['iat'] == future_iat
+    # linter thinks iat is a string, because it's the _claims dict is
+    # of type [str, str].
+    assert int(jwt_svid._claims['iat']) == future_iat
     assert jwt_svid._token == token
 
 

--- a/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
+++ b/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
@@ -328,6 +328,40 @@ def test_parse_and_validate_valid_token_single_string_aud() -> None:
     assert jwt_svid._token == token
 
 
+def test_parse_and_validate_valid_token_future_iat() -> None:
+    """A token whose 'iat' claim is in the future must still validate.
+
+    PyJWT verifies 'iat' by default and rejects such tokens with a
+    "token is not yet valid (iat)" error, so JwtSvid disables 'iat'
+    verification. This guards against a regression of that setting.
+    """
+    future_iat = timegm(
+        (
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(hours=1)
+        ).utctimetuple()
+    )
+    token = jwt.encode(
+        {
+            'aud': list(TEST_AUDIENCE),
+            'sub': TEST_SPIFFE_ID,
+            'exp': TEST_EXPIRY,
+            'iat': future_iat,
+        },
+        algorithm=TEST_ALG,
+        key=TEST_KEY_PEM,
+        headers={'alg': TEST_ALG, 'typ': 'JWT', 'kid': TEST_KEY_ID},
+    )
+
+    jwt_svid = JwtSvid.parse_and_validate(token, JWT_BUNDLE, {'test'})
+
+    assert jwt_svid._audience == TEST_AUDIENCE
+    assert str(jwt_svid._spiffe_id) == TEST_SPIFFE_ID
+    assert jwt_svid._expiry == TEST_EXPIRY
+    assert jwt_svid._claims['iat'] == future_iat
+    assert jwt_svid._token == token
+
+
 def test_parse_and_validate_valid_token_multiple_keys_bundle() -> None:
     ec_key = ec.generate_private_key(ec.SECP521R1(), default_backend())
     jwt_bundle = JwtBundle(


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
JWT-SVID verification

**Description of change**
The pyjwt library verified the 'iat' field [by default](https://github.com/jpadilla/pyjwt/issues/939) even though it's somewhat wrong.

Since this can lead to "token not yet valid", could we disable that extra verification?
