### PR TITLE
Fix FFDH CryptographyDeprecationWarning raised when importing spiffe

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **X.509:** Define `PRIVATE_KEY_TYPES` by aliasing cryptography's canonical `PrivateKeyTypes` instead of hand-maintaining a copy of the union. The previous copy referenced `dh.DHPrivateKey`, which [cryptography 50.0.0 deprecated](https://cryptography.io/en/latest/changelog/#v50-0-0) (FFDH), so touching it emits a `CryptographyDeprecationWarning` at import time; because that warning subclasses `UserWarning`, strict `filterwarnings = error` policies turned importing `spiffe` into an error. The alias also keeps the type in sync with cryptography (e.g. the newer ML-DSA/ML-KEM key types).
+
 ## [0.3.0] - 2026-06-15
 
 ### Breaking

--- a/spiffe/src/spiffe/utils/certificate_utils.py
+++ b/spiffe/src/spiffe/utils/certificate_utils.py
@@ -14,21 +14,12 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
-from typing import List, Iterable, Union
+from typing import List, Iterable
 from pathlib import Path
 import os
 import pem
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric import (
-    ed25519,
-    ed448,
-    rsa,
-    ec,
-    dsa,
-    dh,
-    x25519,
-    x448,
-)
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 from cryptography.hazmat.primitives.serialization import (
     load_der_private_key,
     load_pem_private_key,
@@ -52,16 +43,7 @@ from spiffe.utils.errors import (
 _CERTS_FILE_MODE = 0o644
 _PRIVATE_KEY_FILE_MODE = 0o600
 
-PRIVATE_KEY_TYPES = Union[
-    dh.DHPrivateKey,
-    ed25519.Ed25519PrivateKey,
-    ed448.Ed448PrivateKey,
-    rsa.RSAPrivateKey,
-    dsa.DSAPrivateKey,
-    ec.EllipticCurvePrivateKey,
-    x25519.X25519PrivateKey,
-    x448.X448PrivateKey,
-]
+PRIVATE_KEY_TYPES = PrivateKeyTypes
 
 
 def parse_pem_certificates(pem_bytes: bytes) -> List[Certificate]:


### PR DESCRIPTION
## Summary

`certificate_utils.PRIVATE_KEY_TYPES` is a hand-rolled `Union` that duplicates `cryptography`'s `PrivateKeyTypes`. It was added as `_PRIVATE_KEY_TYPES` in 77537c6 (#41), and `dh.DHPrivateKey` was added to it later in 95b2e32 (#107).

[`cryptography` 50.0.0 deprecated Diffie-Hellman over finite fields (FFDH)](https://cryptography.io/en/latest/changelog/#v50-0-0), so merely touching `dh.DHPrivateKey` now emits a `CryptographyDeprecationWarning` at module import time:

```
cryptography.utils.CryptographyDeprecationWarning: Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use a more modern key exchange algorithm.
```

Because `CryptographyDeprecationWarning` subclasses `UserWarning` (not `DeprecationWarning`), any downstream project that runs under a strict `filterwarnings = error` policy fails to **import `spiffe` at all** — the warning is raised as an error during import, before any code runs.

This became reachable once the `cryptography` upper bound was removed in 429c165 (`>=46,<48` → `>=46`, relaxing the pin from 8deed17), allowing `cryptography` 50 to resolve.

The copied union had also drifted from `cryptography`: it no longer matches what the key loaders can return (e.g. it predates the ML-DSA / ML-KEM key types).

## Change

Alias `cryptography`'s canonical type instead of hand-maintaining a copy:

```python
from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
PRIVATE_KEY_TYPES = PrivateKeyTypes
```

This is exactly what `load_der_private_key` / `load_pem_private_key` are declared to return — both are annotated `-> PrivateKeyTypes` in `cryptography`'s type stub [`hazmat/bindings/_rust/openssl/keys.pyi`](https://github.com/pyca/cryptography/blob/50.0.0/src/cryptography/hazmat/bindings/_rust/openssl/keys.pyi#L13-L26) — and `parse_*_private_key` simply returns those calls, so the annotations now match precisely what is produced. It also removes the deprecated attribute reference and stays in sync with `cryptography` going forward.

`PRIVATE_KEY_TYPES` is only ever used as a type annotation (no runtime `isinstance`), so there is no runtime behaviour change. Lint (ruff/mypy/pyright, 100% type completeness) and the full unit suite (376 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)