### PR TITLE
chore(release): bump spiffe to 0.3.1

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.1] - 2026-08-08
 
 ### Fixed
 - **X.509:** Define `PRIVATE_KEY_TYPES` by aliasing cryptography's canonical `PrivateKeyTypes` instead of hand-maintaining a copy of the union. The previous copy referenced `dh.DHPrivateKey`, which [cryptography 50.0.0 deprecated](https://cryptography.io/en/latest/changelog/#v50-0-0) (FFDH), so touching it emits a `CryptographyDeprecationWarning` at import time; because that warning subclasses `UserWarning`, strict `filterwarnings = error` policies turned importing `spiffe` into an error. The alias also keeps the type in sync with cryptography (e.g. the newer ML-DSA/ML-KEM key types).
+
+### Changed
+- **JWT-SVID:** `JwtSvid.parse_and_validate()` no longer verifies the optional `iat` claim, preventing valid SVIDs from being rejected when issuer and validator clocks differ. Signature, audience, subject, and expiration validation are unchanged.
 
 ## [0.3.0] - 2026-06-15
 

--- a/spiffe/pyproject.toml
+++ b/spiffe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiffe"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python library for SPIFFE support"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ wheels = [
 
 [[package]]
 name = "spiffe"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "spiffe" }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Prepare the `spiffe` 0.3.1 patch release:

- `spiffe/pyproject.toml`: version `0.3.0` → `0.3.1`
- `spiffe/CHANGELOG.md`: dated `[0.3.1]` section covering the two changes merged since 0.3.0
- `uv.lock`: workspace version refresh

No `spiffe-tls` release: it has no changes since 0.4.0, and its `spiffe>=0.3.0,<0.4.0` requirement already resolves to 0.3.1.

## Why

Two user-visible changes have landed since 0.3.0 and are unreleased:

- **#446** — importing `spiffe` raises `CryptographyDeprecationWarning` (FFDH) at import time under cryptography 50. Because that warning subclasses `UserWarning`, downstream projects using `filterwarnings = error` cannot import `spiffe` at all. 
- **#443** — `JwtSvid.parse_and_validate()` no longer verifies the optional `iat` claim, so valid SVIDs are not rejected when issuer and validator clocks differ.

Patch rather than minor: neither change adds API surface, and both are backward-compatible fixes. Keeping the release in the `0.3.x` line also matters here, since a `0.4.0` would fall outside `spiffe-tls`'s `<0.4.0` requirement and outside any downstream cap, which would block exactly the consumers this release is meant to unblock.

## How tested

- `./dev lint` — clean (ruff/mypy/pyright, 100% type completeness)
- `./dev test` — 376 passed (`spiffe`), 20 passed (`spiffe-tls`)
- `./dev build` — `spiffe-0.3.1` sdist/wheel build with correct metadata
- `./dev integration` — not run locally (no SPIRE agent socket); covered by CI, which starts SPIRE
- Verified the fix against the actual failure mode, which CI does not cover (it resolves cryptography 46 via `uv.lock`):
  - `spiffe==0.3.0` + cryptography 50.0.0, `python -W error::UserWarning -c "import spiffe"` → fails with `CryptographyDeprecationWarning` at `certificate_utils.py:56`
  - the built `spiffe-0.3.1` wheel, same command → imports cleanly