### PR TITLE
fix(jwt-svid): reject subject trust domain mismatch against JwtBundle

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **JWT-SVID:** `JwtSvid.parse_and_validate()` now rejects a token whose `sub` claims a SPIFFE ID from a trust domain different from the supplied `JwtBundle`'s trust domain. Previously, a token signed by a key present in the bundle (e.g. a key/`kid` reused across trust domains) could validate even though its subject belonged to another trust domain. Callers validating federated tokens should select the matching bundle (for example via `JwtBundleSet.get_bundle_for_trust_domain`) before calling `parse_and_validate`.
+
 ## [0.3.1] - 2026-08-08
 
 ### Fixed

--- a/spiffe/src/spiffe/svid/jwt_svid.py
+++ b/spiffe/src/spiffe/svid/jwt_svid.py
@@ -123,11 +123,15 @@ class JwtSvid(object):
     ) -> 'JwtSvid':
         """Parses and validates a JWT-SVID token and returns an instance of JwtSvid.
 
-        The JWT-SVID signature is verified using the JWT bundle source.
+        The JWT-SVID signature is verified using the supplied JWT bundle.
+        The bundle's trust domain must equal the trust domain of the SPIFFE ID in
+        the token's 'sub' claim. Callers validating federated tokens should select
+        the matching bundle (for example via JwtBundleSet.get_bundle_for_trust_domain)
+        before calling this method.
 
         Args:
             token: A token as a string that is parsed and validated.
-            jwt_bundle: An instance of JwtBundle that provides the JWT authorities to verify the signature.
+            jwt_bundle: JwtBundle for the subject's trust domain; used to verify the signature.
             audience: A set of strings used to validate the 'aud' claim.
 
         Returns:
@@ -140,10 +144,10 @@ class JwtSvid(object):
                             when the signature cannot be verified, or
                             when the 'aud' claim has an audience that is not in the audience list provided as parameter.
             ArgumentError:     When the token is blank or cannot be parsed.
-            BundleNotFoundError:    If the bundle for the trust domain of the SPIFFE ID from the 'sub'
-                                    cannot be found the jwt_bundle_source.
             AuthorityNotFoundError: If the authority cannot be found in the bundle using the value from the 'kid' header.
-            InvalidTokenError: In case token is malformed and fails to decode.
+            InvalidTokenError: In case token is malformed and fails to decode, or when the trust domain of the
+                                SPIFFE ID from the 'sub' claim does not match the trust domain of the supplied
+                                jwt_bundle.
         """
         if not token:
             raise ArgumentError('token cannot be empty')
@@ -184,6 +188,12 @@ class JwtSvid(object):
             if not sub_claim:
                 raise InvalidTokenError('JWT token must contain a non-empty \'sub\' claim')
             spiffe_id = SpiffeId(sub_claim)
+
+            if spiffe_id.trust_domain != jwt_bundle.trust_domain:
+                raise InvalidTokenError(
+                    f"JWT-SVID subject trust domain '{spiffe_id.trust_domain}' does not match "
+                    f"the trust domain '{jwt_bundle.trust_domain}' of the supplied JwtBundle"
+                )
 
             return JwtSvid(spiffe_id, claims['aud'], claims['exp'], claims, token)
         except PyJWTError as err:

--- a/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
+++ b/spiffe/tests/unit/svid/jwtsvid/test_jwt_svid.py
@@ -25,6 +25,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.hazmat.backends import default_backend
 from spiffe.svid.jwt_svid import JwtSvid
 from spiffe.bundle.jwt_bundle.jwt_bundle import JwtBundle
+from spiffe.spiffe_id.spiffe_id import TrustDomain
 from spiffe.errors import ArgumentError
 from spiffe.svid.errors import (
     TokenExpiredError,
@@ -384,3 +385,76 @@ def test_parse_and_validate_valid_token_multiple_keys_bundle() -> None:
     assert str(jwt_svid2._spiffe_id) == TEST_SPIFFE_ID
     assert jwt_svid2._expiry == TEST_EXPIRY
     assert jwt_svid2._token == token2
+
+
+def _trust_domain_mismatch_message(subject_trust_domain: str, bundle_trust_domain: str) -> str:
+    return (
+        f"JWT-SVID subject trust domain '{subject_trust_domain}' does not match "
+        f"the trust domain '{bundle_trust_domain}' of the supplied JwtBundle"
+    )
+
+
+def test_parse_and_validate_subject_trust_domain_matches_bundle() -> None:
+    """A token whose 'sub' trust domain matches the bundle's trust domain must succeed."""
+    token = generate_test_jwt_token(spiffe_id='spiffe://test.com/workload')
+    jwt_svid = JwtSvid.parse_and_validate(token, JWT_BUNDLE, {'test'})
+    assert str(jwt_svid._spiffe_id) == 'spiffe://test.com/workload'
+    assert jwt_svid._spiffe_id.trust_domain == JWT_BUNDLE.trust_domain
+
+
+def test_parse_and_validate_subject_trust_domain_matches_bundle_case_insensitive() -> None:
+    """Trust domain comparison must use SPIFFE-normalized (lowercase) names."""
+    token = generate_test_jwt_token(spiffe_id='spiffe://TEST.COM/workload')
+    jwt_svid = JwtSvid.parse_and_validate(token, JWT_BUNDLE, {'test'})
+    assert str(jwt_svid._spiffe_id) == 'spiffe://test.com/workload'
+    assert jwt_svid._spiffe_id.trust_domain == JWT_BUNDLE.trust_domain
+
+
+@pytest.mark.parametrize(
+    'subject_spiffe_id',
+    [
+        'spiffe://other.org/workload',
+        'spiffe://evil-test.com/workload',
+        'spiffe://test.com.evil.org/workload',
+    ],
+)
+def test_parse_and_validate_subject_trust_domain_mismatch(subject_spiffe_id: str) -> None:
+    """A correctly signed token whose 'sub' claims a different trust domain than the
+    supplied JwtBundle must be rejected, including lookalike / suffix-confusion domains.
+    """
+    token = generate_test_jwt_token(spiffe_id=subject_spiffe_id)
+    subject_trust_domain = TrustDomain(subject_spiffe_id)
+    expected = _trust_domain_mismatch_message(
+        str(subject_trust_domain), str(TEST_TRUST_DOMAIN)
+    )
+
+    with pytest.raises(InvalidTokenError) as exception:
+        JwtSvid.parse_and_validate(token, JWT_BUNDLE, {'test'})
+
+    assert str(exception.value) == expected
+
+
+def test_parse_and_validate_subject_trust_domain_mismatch_shared_key_across_bundles() -> None:
+    """Reusing the same signing key and 'kid' across bundles for two different trust
+    domains must not allow a token issued for one trust domain to validate against a
+    JwtBundle for a different trust domain.
+    """
+    trust_domain_b = TrustDomain('other.org')
+    shared_kid = 'shared-kid'
+    jwt_bundle_a = JwtBundle(TEST_TRUST_DOMAIN, {shared_kid: TEST_KEY.public_key()})
+    jwt_bundle_b = JwtBundle(trust_domain_b, {shared_kid: TEST_KEY.public_key()})
+
+    token_for_b = generate_test_jwt_token(
+        kid=shared_kid, spiffe_id='spiffe://other.org/workload'
+    )
+    expected = _trust_domain_mismatch_message('other.org', 'test.com')
+
+    # Signature verifies fine against bundle_a (same key/kid reused), but the subject's
+    # trust domain does not match bundle_a's trust domain, so it must be rejected.
+    with pytest.raises(InvalidTokenError) as exception:
+        JwtSvid.parse_and_validate(token_for_b, jwt_bundle_a, {'test'})
+    assert str(exception.value) == expected
+
+    # Validating against the correct bundle (matching trust domain) succeeds.
+    jwt_svid = JwtSvid.parse_and_validate(token_for_b, jwt_bundle_b, {'test'})
+    assert str(jwt_svid._spiffe_id) == 'spiffe://other.org/workload'


### PR DESCRIPTION
## What
`JwtSvid.parse_and_validate()` now rejects a JWT-SVID when the `sub` SPIFFE ID trust domain does not match the supplied `JwtBundle` trust domain. Changelog and docstring updated; stale `BundleNotFoundError` docs removed.

## Why
A token signed by a key present in the supplied bundle (including key/`kid` reuse across trust domains) could previously validate even when `sub` claimed a different trust domain. SPIFFE requires validators to use the bundle for the subject's trust domain.

## How tested
- Unit tests for matching trust domains (including case-normalized IDs)
- Rejection cases for mismatched and lookalike trust domains
- Shared key/`kid` across two bundles: wrong-bundle validation fails; matching-bundle validation succeeds