### PR TITLE
fix(workloadapi): reconnect watchers on stream EOF

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Workload API:** X.509 and JWT watchers now reconnect when an active response stream ends normally, preserve retry state until a valid update is delivered, and treat explicit cancellation as a silent terminal condition.
+
 ## [0.3.1] - 2026-08-08
 
 ### Fixed

--- a/spiffe/src/spiffe/workloadapi/workload_api_client.py
+++ b/spiffe/src/spiffe/workloadapi/workload_api_client.py
@@ -64,6 +64,8 @@ _logger = logging.getLogger(__name__)
 #  - CANCELLED is not retried because it occurs when the caller has canceled the operation.
 _NON_RETRYABLE_CODES = {grpc.StatusCode.CANCELLED, grpc.StatusCode.INVALID_ARGUMENT}
 
+_STREAM_ENDED_ERROR = 'Workload API stream ended unexpectedly'
+
 __all__ = ['WorkloadApiClient', 'RetryPolicy']
 
 _T_co = TypeVar("_T_co", covariant=True)
@@ -124,6 +126,10 @@ class RetryHandler:
         """Determines whether the operation should be retried based on the error code and attempt count."""
         if error_code in _NON_RETRYABLE_CODES:
             return False
+        return self.can_retry()
+
+    def can_retry(self) -> bool:
+        """Determines whether the retry limit allows another attempt."""
         # Allow unlimited retries when max_retries is set to UNLIMITED_RETRIES (0)
         if (
             self.retry_policy.max_retries != RetryPolicy.UNLIMITED_RETRIES
@@ -170,7 +176,10 @@ class StreamCancelHandler:
         self._cancel_event.set()
         with self._lock:
             if self.response_iterator:
-                self.response_iterator.cancel()
+                try:
+                    self.response_iterator.cancel()
+                except Exception:
+                    pass
 
     def is_cancelled(self) -> bool:
         return self._cancel_event.is_set()
@@ -443,13 +452,19 @@ class WorkloadApiClient:
         Establishes a streaming gRPC connection to receive continuous updates of X.509 contexts from the Workload API.
 
         This method asynchronously listens for X.509 context updates, invoking `on_success` with each new context received.
-        If an error occurs during streaming or processing, `on_error` is called with the encountered exception. The method
-        supports automatic reconnection attempts based on the specified `retry_policy`.
+        If an error occurs during streaming or processing, `on_error` is called with the encountered exception.
+
+        While the watcher remains active, a normal end of the response stream is not treated as permanent completion.
+        When `retry_connect` is True, the client reconnects according to `retry_policy` (retry/backoff state resets only
+        after a valid update is delivered). When `retry_connect` is False, stream end is fail-closed and `on_error` is
+        called. Calling `cancel()` on the returned handler stops the watcher promptly without invoking `on_error` or
+        starting another connection.
 
         Parameters:
             on_success (Callable[[X509Context], None]): Callback for each update received.
-            on_error (Callable[[Exception], None]): Callback for handling streaming or processing errors.
-            retry_connect (bool, optional): Enables automatic retries on connection failures. Defaults to True.
+            on_error (Callable[[Exception], None]): Callback for streaming, processing, or fail-closed stream-end errors.
+            retry_connect (bool, optional): Enables automatic retries on stream end and connection failures.
+                Defaults to True.
             retry_policy (Optional[RetryPolicy], optional): Custom retry behavior; uses default if None.
 
         Returns:
@@ -484,20 +499,26 @@ class WorkloadApiClient:
         Establishes a streaming gRPC connection to receive continuous updates of Jwt Bundles from the Workload API.
 
         This method asynchronously listens for Jwt Bundles updates, invoking `on_success` with each new update received.
-        If an error occurs during streaming or processing, `on_error` is called with the encountered exception. The method
-        supports automatic reconnection attempts based on the specified `retry_policy`.
+        If an error occurs during streaming or processing, `on_error` is called with the encountered exception.
+
+        While the watcher remains active, a normal end of the response stream is not treated as permanent completion.
+        When `retry_connect` is True, the client reconnects according to `retry_policy` (retry/backoff state resets only
+        after a valid update is delivered). When `retry_connect` is False, stream end is fail-closed and `on_error` is
+        called. Calling `cancel()` on the returned handler stops the watcher promptly without invoking `on_error` or
+        starting another connection.
 
         Parameters:
-            on_success (Callable[[X509Context], None]): Callback for each update received.
-            on_error (Callable[[Exception], None]): Callback for handling streaming or processing errors.
-            retry_connect (bool, optional): Enables automatic retries on connection failures. Defaults to True.
+            on_success (Callable[[JwtBundleSet], None]): Callback for each update received.
+            on_error (Callable[[Exception], None]): Callback for streaming, processing, or fail-closed stream-end errors.
+            retry_connect (bool, optional): Enables automatic retries on stream end and connection failures.
+                Defaults to True.
             retry_policy (Optional[RetryPolicy], optional): Custom retry behavior; uses default if None.
 
         Returns:
             StreamCancelHandler: A handler that can be used to cancel the streaming operation.
 
         Usage example:
-            cancel_handler = client.stream_x509_contexts(on_success, on_error)
+            cancel_handler = client.stream_jwt_bundles(on_success, on_error)
             # To cancel the streaming:
             cancel_handler.cancel()
         """
@@ -549,12 +570,17 @@ class WorkloadApiClient:
                         break
                     x509_context = self._process_x509_context(item)
                     on_success(x509_context)
+                    if retry_handler:
+                        retry_handler.reset()
 
-                if retry_handler:
-                    retry_handler.reset()
-                break
+                if not self._reconnect_after_stream_end(
+                    cancel_handler, retry_handler, on_error
+                ):
+                    break
 
             except grpc.RpcError as grpc_err:
+                if cancel_handler.is_cancelled():
+                    break
                 if retry_handler is None or not retry_handler.should_retry(grpc_err.code()):
                     on_error(WorkloadApiError(f"gRPC error: {str(grpc_err.code())}"))
                     break
@@ -564,6 +590,8 @@ class WorkloadApiClient:
                     break
 
             except Exception as err:
+                if cancel_handler.is_cancelled():
+                    break
                 on_error(WorkloadApiError(str(err)))
                 break  # Exit on unexpected errors
 
@@ -588,12 +616,17 @@ class WorkloadApiClient:
                         break
                     jwt_bundles = self._process_jwt_bundles(item)
                     on_success(jwt_bundles)
+                    if retry_handler:
+                        retry_handler.reset()
 
-                if retry_handler:
-                    retry_handler.reset()
-                break
+                if not self._reconnect_after_stream_end(
+                    cancel_handler, retry_handler, on_error
+                ):
+                    break
 
             except grpc.RpcError as grpc_err:
+                if cancel_handler.is_cancelled():
+                    break
                 if retry_handler is None or not retry_handler.should_retry(grpc_err.code()):
                     on_error(WorkloadApiError(f"gRPC error: {str(grpc_err.code())}"))
                     break
@@ -603,8 +636,27 @@ class WorkloadApiClient:
                     break
 
             except Exception as err:
+                if cancel_handler.is_cancelled():
+                    break
                 on_error(WorkloadApiError(str(err)))
                 break  # Exit on unexpected errors
+
+    @staticmethod
+    def _reconnect_after_stream_end(
+        cancel_handler: StreamCancelHandler,
+        retry_handler: Optional[RetryHandler],
+        on_error: Callable[[Exception], None],
+    ) -> bool:
+        if cancel_handler.is_cancelled():
+            return False
+
+        if retry_handler is None or not retry_handler.can_retry():
+            if not cancel_handler.is_cancelled():
+                on_error(WorkloadApiError(_STREAM_ENDED_ERROR))
+            return False
+
+        backoff = retry_handler.get_backoff()
+        return not cancel_handler.wait_cancelled(backoff)
 
     def _process_x509_context(
         self, x509_svid_response: workload_pb2.X509SVIDResponse

--- a/spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py
+++ b/spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py
@@ -16,7 +16,7 @@ under the License.
 
 from collections.abc import Iterator
 import threading
-from typing import Generic, TypeVar
+from typing import Callable, Generic, TypeVar
 from unittest.mock import patch
 
 import grpc
@@ -33,7 +33,12 @@ from spiffe.workloadapi.errors import (
     FetchX509BundleError,
     WorkloadApiError,
 )
-from spiffe.workloadapi.workload_api_client import WorkloadApiClient
+from spiffe.workloadapi.workload_api_client import (
+    RetryHandler,
+    RetryPolicy,
+    StreamCancelHandler,
+    WorkloadApiClient,
+)
 from spiffe.workloadapi.x509_context import X509Context
 from testutils.certs import (
     CHAIN1,
@@ -62,10 +67,12 @@ class _FakeStream(Generic[_T]):
         *,
         error: Exception | None = None,
         cancel_error: Exception | None = None,
+        on_eof: Callable[[], None] | None = None,
     ) -> None:
         self._responses = iter(responses or [])
         self._error = error
         self._cancel_error = cancel_error
+        self._on_eof = on_eof
         self.cancel_count = 0
 
     def __iter__(self) -> '_FakeStream[_T]':
@@ -74,13 +81,30 @@ class _FakeStream(Generic[_T]):
     def __next__(self) -> _T:
         if self._error:
             raise self._error
-        return next(self._responses)
+        try:
+            return next(self._responses)
+        except StopIteration:
+            if self._on_eof:
+                on_eof = self._on_eof
+                self._on_eof = None
+                on_eof()
+            raise
 
     def cancel(self) -> bool:
         self.cancel_count += 1
         if self._cancel_error:
             raise self._cancel_error
         return True
+
+
+class _RecordingCancelHandler(StreamCancelHandler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.backoffs: list[float] = []
+
+    def wait_cancelled(self, timeout: float) -> bool:
+        self.backoffs.append(timeout)
+        return self.is_cancelled()
 
 
 @pytest.fixture
@@ -791,43 +815,68 @@ def test_fetch_x509_bundles_corrupted_federated_bundle(
     )
 
 
+def _x509_stream_response(
+    spiffe_id: str = 'spiffe://example.org/service',
+    chain: bytes = CHAIN1,
+    key: bytes = KEY1,
+) -> workload_pb2.X509SVIDResponse:
+    return workload_pb2.X509SVIDResponse(
+        svids=[
+            workload_pb2.X509SVID(
+                spiffe_id=spiffe_id,
+                x509_svid=chain,
+                x509_svid_key=key,
+                bundle=BUNDLE,
+            )
+        ]
+    )
+
+
 def test_stream_x509_contexts_success(
     mocker: MockerFixture, client: WorkloadApiClient
 ) -> None:
     federated_bundles = {'domain.test': FEDERATED_BUNDLE}
 
-    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(
-        return_value=iter(
-            [
-                workload_pb2.X509SVIDResponse(
-                    svids=[
-                        workload_pb2.X509SVID(
-                            spiffe_id='spiffe://example.org/service',
-                            x509_svid=CHAIN1,
-                            x509_svid_key=KEY1,
-                            bundle=BUNDLE,
-                        ),
-                        workload_pb2.X509SVID(
-                            spiffe_id='spiffe://example.org/service2',
-                            x509_svid=CHAIN2,
-                            x509_svid_key=KEY2,
-                            bundle=BUNDLE,
-                        ),
-                    ],
-                    federated_bundles=federated_bundles,
-                )
-            ]
-        )
+    stream = _FakeStream(
+        [
+            workload_pb2.X509SVIDResponse(
+                svids=[
+                    workload_pb2.X509SVID(
+                        spiffe_id='spiffe://example.org/service',
+                        x509_svid=CHAIN1,
+                        x509_svid_key=KEY1,
+                        bundle=BUNDLE,
+                    ),
+                    workload_pb2.X509SVID(
+                        spiffe_id='spiffe://example.org/service2',
+                        x509_svid=CHAIN2,
+                        x509_svid_key=KEY2,
+                        bundle=BUNDLE,
+                    ),
+                ],
+                federated_bundles=federated_bundles,
+            )
+        ]
     )
+    client._spiffe_workload_api_stub.FetchX509SVID = mocker.Mock(return_value=stream)
 
     done = threading.Event()
+    cancel_handler_ready = threading.Event()
     response_holder = ResponseHolder[X509Context]()
+    cancel_handler: StreamCancelHandler | None = None
 
-    client.stream_x509_contexts(
-        lambda r: handle_success(r, response_holder, done),
+    def on_success(response: X509Context) -> None:
+        handle_success(response, response_holder, done)
+        assert cancel_handler_ready.wait(timeout=5)
+        assert cancel_handler is not None
+        cancel_handler.cancel()
+
+    cancel_handler = client.stream_x509_contexts(
+        on_success,
         lambda e: handle_error(e, response_holder, done),
         retry_connect=True,
     )
+    cancel_handler_ready.set()
 
     done.wait(timeout=5)
 
@@ -852,6 +901,154 @@ def test_stream_x509_contexts_success(
     assert len(bundle.x509_authorities) == 1
 
 
+def test_stream_x509_contexts_reconnects_after_eof_and_delivers_rotated_update(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_x509_svid = mocker.Mock(
+        side_effect=[
+            _FakeStream([_x509_stream_response()]),
+            _FakeStream(
+                [_x509_stream_response('spiffe://example.org/service2', CHAIN2, KEY2)]
+            ),
+        ]
+    )
+    client._spiffe_workload_api_stub.FetchX509SVID = fetch_x509_svid
+    cancel_handler = StreamCancelHandler()
+    responses: list[X509Context] = []
+    errors: list[Exception] = []
+
+    def on_success(response: X509Context) -> None:
+        responses.append(response)
+        if len(responses) == 2:
+            cancel_handler.cancel()
+
+    client._watch_x509_context_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        on_success,
+        errors.append,
+    )
+
+    assert [str(response.default_svid.spiffe_id) for response in responses] == [
+        'spiffe://example.org/service',
+        'spiffe://example.org/service2',
+    ]
+    assert responses[0].default_svid.leaf != responses[1].default_svid.leaf
+    assert errors == []
+    assert fetch_x509_svid.call_count == 2
+
+
+def test_stream_x509_contexts_cancellation_during_iteration_is_silent(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_x509_svid = mocker.Mock(
+        return_value=_FakeStream(
+            [
+                _x509_stream_response(),
+                _x509_stream_response('spiffe://example.org/not-delivered', CHAIN2, KEY2),
+            ]
+        )
+    )
+    client._spiffe_workload_api_stub.FetchX509SVID = fetch_x509_svid
+    cancel_handler = StreamCancelHandler()
+    responses: list[X509Context] = []
+    errors: list[Exception] = []
+
+    def on_success(response: X509Context) -> None:
+        responses.append(response)
+        cancel_handler.cancel()
+
+    client._watch_x509_context_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        on_success,
+        errors.append,
+    )
+
+    assert len(responses) == 1
+    assert errors == []
+    assert fetch_x509_svid.call_count == 1
+
+
+def test_stream_x509_contexts_cancellation_at_eof_is_silent(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    cancel_handler = StreamCancelHandler()
+    stream = _FakeStream([_x509_stream_response()], on_eof=cancel_handler.cancel)
+    fetch_x509_svid = mocker.Mock(return_value=stream)
+    client._spiffe_workload_api_stub.FetchX509SVID = fetch_x509_svid
+    errors: list[Exception] = []
+
+    client._watch_x509_context_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        lambda _: None,
+        errors.append,
+    )
+
+    assert errors == []
+    assert fetch_x509_svid.call_count == 1
+
+
+def test_stream_x509_contexts_retry_state_resets_only_after_delivered_update(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_x509_svid = mocker.Mock(
+        side_effect=[
+            _FakeStream(),
+            _FakeStream(),
+            _FakeStream([_x509_stream_response()]),
+            _FakeStream(
+                [_x509_stream_response('spiffe://example.org/service2', CHAIN2, KEY2)]
+            ),
+        ]
+    )
+    client._spiffe_workload_api_stub.FetchX509SVID = fetch_x509_svid
+    cancel_handler = _RecordingCancelHandler()
+    responses: list[X509Context] = []
+    errors: list[Exception] = []
+
+    def on_success(response: X509Context) -> None:
+        responses.append(response)
+        if len(responses) == 2:
+            cancel_handler.cancel()
+
+    client._watch_x509_context_updates(
+        cancel_handler,
+        RetryHandler(
+            RetryPolicy(
+                max_retries=3,
+                base_backoff_in_seconds=1,
+                backoff_factor=2,
+                max_backoff=10,
+            )
+        ),
+        on_success,
+        errors.append,
+    )
+
+    assert errors == []
+    assert cancel_handler.backoffs == [1, 2, 1]
+    assert fetch_x509_svid.call_count == 4
+
+
+def test_stream_x509_contexts_eof_without_retry_reports_error(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_x509_svid = mocker.Mock(return_value=_FakeStream())
+    client._spiffe_workload_api_stub.FetchX509SVID = fetch_x509_svid
+    errors: list[Exception] = []
+
+    client._watch_x509_context_updates(
+        StreamCancelHandler(), None, lambda _: pytest.fail('unexpected update'), errors.append
+    )
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], WorkloadApiError)
+    assert str(errors[0]) == 'Workload API stream ended unexpectedly'
+    assert fetch_x509_svid.call_count == 1
+
+
 def test_stream_x509_contexts_raise_retryable_grpc_error_and_then_ok_response(
     mocker: MockerFixture, client: WorkloadApiClient
 ) -> None:
@@ -864,14 +1061,23 @@ def test_stream_x509_contexts_raise_retryable_grpc_error_and_then_ok_response(
 
     expected_error = FetchX509SvidError('StatusCode.DEADLINE_EXCEEDED')
     done = threading.Event()
+    cancel_handler_ready = threading.Event()
 
     response_holder = ResponseHolder[X509Context]()
+    cancel_handler: StreamCancelHandler | None = None
 
-    client.stream_x509_contexts(
-        lambda r: handle_success(r, response_holder, done),
+    def on_success(response: X509Context) -> None:
+        handle_success(response, response_holder, done)
+        assert cancel_handler_ready.wait(timeout=5)
+        assert cancel_handler is not None
+        cancel_handler.cancel()
+
+    cancel_handler = client.stream_x509_contexts(
+        on_success,
         lambda e: assert_error(e, expected_error),
         True,
     )
+    cancel_handler_ready.set()
 
     done.wait(timeout=90)
 

--- a/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
+++ b/spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py
@@ -16,7 +16,7 @@ under the License.
 
 from collections import deque
 from collections.abc import Iterator
-from typing import Generic, List, TypeVar
+from typing import Callable, Generic, List, TypeVar
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +27,12 @@ from pytest_mock import MockerFixture
 
 from spiffe._proto import workload_pb2
 from spiffe.bundle.jwt_bundle.jwt_bundle_set import JwtBundleSet
-from spiffe.workloadapi.workload_api_client import WorkloadApiClient
+from spiffe.workloadapi.workload_api_client import (
+    RetryHandler,
+    RetryPolicy,
+    StreamCancelHandler,
+    WorkloadApiClient,
+)
 from spiffe.spiffe_id.spiffe_id import TrustDomain
 from spiffe.spiffe_id.spiffe_id import SpiffeId
 from spiffe.errors import ArgumentError
@@ -62,10 +67,12 @@ class _FakeStream(Generic[_T]):
         *,
         error: Exception | None = None,
         cancel_error: Exception | None = None,
+        on_eof: Callable[[], None] | None = None,
     ) -> None:
         self._responses = iter(responses or [])
         self._error = error
         self._cancel_error = cancel_error
+        self._on_eof = on_eof
         self.cancel_count = 0
 
     def __iter__(self) -> '_FakeStream[_T]':
@@ -74,13 +81,30 @@ class _FakeStream(Generic[_T]):
     def __next__(self) -> _T:
         if self._error:
             raise self._error
-        return next(self._responses)
+        try:
+            return next(self._responses)
+        except StopIteration:
+            if self._on_eof:
+                on_eof = self._on_eof
+                self._on_eof = None
+                on_eof()
+            raise
 
     def cancel(self) -> bool:
         self.cancel_count += 1
         if self._cancel_error:
             raise self._cancel_error
         return True
+
+
+class _RecordingCancelHandler(StreamCancelHandler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.backoffs: list[float] = []
+
+    def wait_cancelled(self, timeout: float) -> bool:
+        self.backoffs.append(timeout)
+        return self.is_cancelled()
 
 
 @pytest.fixture
@@ -550,7 +574,7 @@ def test_stream_jwt_bundles_success(mocker: MockerFixture, client: WorkloadApiCl
 
     # Configure the mock for FetchJWTBundles
     client._spiffe_workload_api_stub.FetchJWTBundles = mocker.Mock(
-        return_value=delayed_responses(
+        return_value=_FakeStream(
             [
                 workload_pb2.JWTBundlesResponse(bundles=jwt_bundles),
                 workload_pb2.JWTBundlesResponse(bundles=jwt_bundles_2),
@@ -559,21 +583,31 @@ def test_stream_jwt_bundles_success(mocker: MockerFixture, client: WorkloadApiCl
     )
 
     update_event = threading.Event()
+    cancel_handler_ready = threading.Event()
     responses: deque[JwtBundleSet] = deque()
+    response_count = 0
+    cancel_handler: StreamCancelHandler | None = None
 
     def on_success_handler(response: JwtBundleSet) -> None:
+        nonlocal response_count
+        response_count += 1
         responses.append(response)
         update_event.set()  # Signal that a new response is available
+        if response_count == 2:
+            assert cancel_handler_ready.wait(timeout=5)
+            assert cancel_handler is not None
+            cancel_handler.cancel()
 
     def on_error_handler(error: Exception) -> None:
         print(f"Error: {error}")
         update_event.set()
 
     # Start streaming
-    client.stream_jwt_bundles(
+    cancel_handler = client.stream_jwt_bundles(
         on_success=on_success_handler,
         on_error=on_error_handler,
     )
+    cancel_handler_ready.set()
 
     # Wait for the first update
     update_event.wait(timeout=5)
@@ -606,6 +640,153 @@ def delayed_responses(
         yield res  # Assuming this delay simulates asynchronous behavior well enough for the test.
 
 
+def _jwt_stream_response(
+    bundles: dict[str, bytes] | None = None,
+) -> workload_pb2.JWTBundlesResponse:
+    return workload_pb2.JWTBundlesResponse(bundles=bundles or {'example.org': JWKS_1_EC_KEY})
+
+
+def test_stream_jwt_bundles_reconnects_after_eof_and_delivers_rotated_update(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_jwt_bundles = mocker.Mock(
+        side_effect=[
+            _FakeStream([_jwt_stream_response()]),
+            _FakeStream([_jwt_stream_response({'domain.dev': JWKS_2_EC_1_RSA_KEYS})]),
+        ]
+    )
+    client._spiffe_workload_api_stub.FetchJWTBundles = fetch_jwt_bundles
+    cancel_handler = StreamCancelHandler()
+    responses: list[JwtBundleSet] = []
+    errors: list[Exception] = []
+
+    def on_success(response: JwtBundleSet) -> None:
+        responses.append(response)
+        if len(responses) == 2:
+            cancel_handler.cancel()
+
+    client._watch_jwt_bundles_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        on_success,
+        errors.append,
+    )
+
+    assert responses[0].get_bundle_for_trust_domain(TrustDomain('example.org'))
+    assert responses[1].get_bundle_for_trust_domain(TrustDomain('domain.dev'))
+    assert errors == []
+    assert fetch_jwt_bundles.call_count == 2
+
+
+def test_stream_jwt_bundles_cancellation_during_iteration_is_silent(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_jwt_bundles = mocker.Mock(
+        return_value=_FakeStream(
+            [
+                _jwt_stream_response(),
+                _jwt_stream_response({'domain.dev': JWKS_1_EC_KEY}),
+            ]
+        )
+    )
+    client._spiffe_workload_api_stub.FetchJWTBundles = fetch_jwt_bundles
+    cancel_handler = StreamCancelHandler()
+    responses: list[JwtBundleSet] = []
+    errors: list[Exception] = []
+
+    def on_success(response: JwtBundleSet) -> None:
+        responses.append(response)
+        cancel_handler.cancel()
+
+    client._watch_jwt_bundles_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        on_success,
+        errors.append,
+    )
+
+    assert len(responses) == 1
+    assert errors == []
+    assert fetch_jwt_bundles.call_count == 1
+
+
+def test_stream_jwt_bundles_cancellation_at_eof_is_silent(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    cancel_handler = StreamCancelHandler()
+    stream = _FakeStream([_jwt_stream_response()], on_eof=cancel_handler.cancel)
+    fetch_jwt_bundles = mocker.Mock(return_value=stream)
+    client._spiffe_workload_api_stub.FetchJWTBundles = fetch_jwt_bundles
+    errors: list[Exception] = []
+
+    client._watch_jwt_bundles_updates(
+        cancel_handler,
+        RetryHandler(RetryPolicy(base_backoff_in_seconds=0)),
+        lambda _: None,
+        errors.append,
+    )
+
+    assert errors == []
+    assert fetch_jwt_bundles.call_count == 1
+
+
+def test_stream_jwt_bundles_retry_state_resets_only_after_delivered_update(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_jwt_bundles = mocker.Mock(
+        side_effect=[
+            _FakeStream(),
+            _FakeStream(),
+            _FakeStream([_jwt_stream_response()]),
+            _FakeStream([_jwt_stream_response({'domain.dev': JWKS_1_EC_KEY})]),
+        ]
+    )
+    client._spiffe_workload_api_stub.FetchJWTBundles = fetch_jwt_bundles
+    cancel_handler = _RecordingCancelHandler()
+    responses: list[JwtBundleSet] = []
+    errors: list[Exception] = []
+
+    def on_success(response: JwtBundleSet) -> None:
+        responses.append(response)
+        if len(responses) == 2:
+            cancel_handler.cancel()
+
+    client._watch_jwt_bundles_updates(
+        cancel_handler,
+        RetryHandler(
+            RetryPolicy(
+                max_retries=3,
+                base_backoff_in_seconds=1,
+                backoff_factor=2,
+                max_backoff=10,
+            )
+        ),
+        on_success,
+        errors.append,
+    )
+
+    assert errors == []
+    assert cancel_handler.backoffs == [1, 2, 1]
+    assert fetch_jwt_bundles.call_count == 4
+
+
+def test_stream_jwt_bundles_eof_without_retry_reports_error(
+    mocker: MockerFixture, client: WorkloadApiClient
+) -> None:
+    fetch_jwt_bundles = mocker.Mock(return_value=_FakeStream())
+    client._spiffe_workload_api_stub.FetchJWTBundles = fetch_jwt_bundles
+    errors: list[Exception] = []
+
+    client._watch_jwt_bundles_updates(
+        StreamCancelHandler(), None, lambda _: pytest.fail('unexpected update'), errors.append
+    )
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], WorkloadApiError)
+    assert str(errors[0]) == 'Workload API stream ended unexpectedly'
+    assert fetch_jwt_bundles.call_count == 1
+
+
 def test_stream_jwt_bundles_retry_on_grpc_error(
     mocker: MockerFixture, client: WorkloadApiClient
 ) -> None:
@@ -621,12 +802,21 @@ def test_stream_jwt_bundles_retry_on_grpc_error(
 
     expected_error = FetchJwtBundleError(grpc_error.details())
     event = threading.Event()
+    cancel_handler_ready = threading.Event()
     response_holder = ResponseHolder[JwtBundleSet]()
+    cancel_handler: StreamCancelHandler | None = None
 
-    client.stream_jwt_bundles(
-        on_success=lambda r: handle_success(r, response_holder, event),
+    def on_success(response: JwtBundleSet) -> None:
+        handle_success(response, response_holder, event)
+        assert cancel_handler_ready.wait(timeout=5)
+        assert cancel_handler is not None
+        cancel_handler.cancel()
+
+    cancel_handler = client.stream_jwt_bundles(
+        on_success=on_success,
         on_error=lambda e: assert_error(e, expected_error),
     )
+    cancel_handler_ready.set()
 
     event.wait(timeout=5)
 


### PR DESCRIPTION
## What
Fix X.509 and JWT Workload API watcher lifecycle for normal stream EOF, explicit cancellation, and retry state.

While a watcher is active, a finite response stream ending normally reconnects per the retry policy instead of being treated as permanent success. Retry/backoff state resets only after a valid update is delivered. User cancellation exits promptly and silently (no `on_error`, no reconnect). With retries disabled, stream end remains fail-closed via `on_error`. Public stream method docs now describe this contract.

## Why
Watchers previously treated normal EOF as successful completion and could reset retry state just because an iterator ended. That stopped rotation updates after a stream close and could report errors (or reconnect) on explicit cancel. Sources and long-lived callers need fail-closed, cancel-safe, reconnect-on-EOF semantics for both X.509 and JWT streams.

## How tested
- Added deterministic X.509 and JWT unit tests with finite fake iterators covering: EOF reconnect + rotated update, silent cancel during/at EOF, retry reset after delivered update, and fail-closed EOF with retries disabled.
- Updated existing finite-stream success/retry tests to cancel intentionally so they do not hang under reconnect.
- Ran: `pytest spiffe/tests/unit/workloadapi/test_workload_api_client_fetch_x509.py spiffe/tests/unit/workloadapi/test_workload_api_client_jwt.py` (80 passed)